### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # TREXIO
 TREX I/O library
+
+Note: The code should be compliant with the C99 [CERT C coding
+standard](https://resources.sei.cmu.edu/downloads/secure-coding/assets/sei-cert-c-coding-standard-2016-v01.pdf). This can be checked with the `cppcheck` tool.

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,16 +44,16 @@ export CC CFLAGS FC FFLAGS LIBS
 
 .PHONY: clean
 
-cppcheck.out: $(HEADER_FILES) $(SOURCE_FILES)
-	cppcheck --addon=cert -q --error-exitcode=0  \
-          --enable=style,warning,unusedFunction,performance,portability,missingInclude \
-          --language=c -rp --std=c99 -v $(SOURCE_FILES) 2>$@
-
 libtrexio.so: $(OBJECT_FILES) $(HEADER_FILES) cppcheck.out
 	$(CC) -shared $(OBJECT_FILES) -o libtrexio.so
 
 fortran: libtrexio.so trexio_f.f90
 	$(FC) $(FFLAGS) -c trexio_f.f90 -o trexio_f.o
+
+cppcheck.out: $(HEADER_FILES) $(SOURCE_FILES)
+	cppcheck --addon=cert -q --error-exitcode=0  \
+          --enable=style,warning,unusedFunction,performance,portability,missingInclude \
+          --language=c -rp --std=c99 -v $(SOURCE_FILES) 2>$@
 
 test_c: libtrexio.so test.c
 	$(CC) $(CFLAGS) $(INCLUDE) -Wl,-rpath,$(PWD) -L. test.c -ltrexio $(LIBS) -o test_c

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,13 +37,19 @@ endif
 RM=rm -f
 
 OBJECT_FILES= trexio.o trexio_text.o trexio_hdf5.o
+SOURCE_FILES= test.c trexio.c trexio_hdf5.c trexio_text.c
 HEADER_FILES= trexio.h trexio_text.h trexio_hdf5.h trexio_s.h
 
 export CC CFLAGS FC FFLAGS LIBS
 
 .PHONY: clean
 
-libtrexio.so: $(OBJECT_FILES) $(HEADER_FILES)
+cppcheck.out: $(HEADER_FILES) $(SOURCE_FILES)
+	cppcheck --addon=cert -q --error-exitcode=1  \
+          --enable=style,warning,unusedFunction,performance,portability,missingInclude \
+          --language=c -rp --std=c99 -v $(SOURCE_FILES) 2>$@
+
+libtrexio.so: $(OBJECT_FILES) $(HEADER_FILES) cppcheck.out
 	$(CC) -shared $(OBJECT_FILES) -o libtrexio.so
 
 fortran: libtrexio.so trexio_f.f90

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,8 +52,9 @@ fortran: libtrexio.so trexio_f.f90
 
 cppcheck.out: $(HEADER_FILES) $(SOURCE_FILES)
 	cppcheck --addon=cert -q --error-exitcode=0  \
-          --enable=style,warning,unusedFunction,performance,portability,missingInclude \
-          --language=c -rp --std=c99 -v $(SOURCE_FILES) 2>$@
+          --enable=warning,performance,portability,missingInclude,information \
+          --language=c --std=c99 -rp --platform=unix64  \
+          $(INCLUDE) $(SOURCE_FILES) 2>$@
 
 test_c: libtrexio.so test.c
 	$(CC) $(CFLAGS) $(INCLUDE) -Wl,-rpath,$(PWD) -L. test.c -ltrexio $(LIBS) -o test_c

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ export CC CFLAGS FC FFLAGS LIBS
 .PHONY: clean
 
 cppcheck.out: $(HEADER_FILES) $(SOURCE_FILES)
-	cppcheck --addon=cert -q --error-exitcode=1  \
+	cppcheck --addon=cert -q --error-exitcode=0  \
           --enable=style,warning,unusedFunction,performance,portability,missingInclude \
           --language=c -rp --std=c99 -v $(SOURCE_FILES) 2>$@
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 
 from os import listdir, scandir, remove
@@ -16,7 +18,7 @@ del config0['metadata']
 config = {}
 for k,v in config0.items():
     if k == 'nucleus' or k == 'ecp':
-    #if k == 'nucleus': 
+    #if k == 'nucleus':
         config[k] = v
 
 groups = [group for group in config.keys()]
@@ -31,9 +33,9 @@ for k1,v1 in config.items():
             if not dim.isdigit():
                 tmp = dim.replace('.','_')
                 dim_variables[tmp] = 0
-                if dim not in dim_list: 
+                if dim not in dim_list:
                     dim_list.append(tmp)
-                    
+
                 dim_dict[grname] = dim_list
                 dim_list = []
 
@@ -60,14 +62,14 @@ for k,v in datasets.items():
         elif v[0] == 'int':
             datatype = 'int64_t'
         tmp_dict['dtype'] = datatype
-        tmp_dict['dims'] = [dim.replace('.','_') for dim in v[1]] 
-        tmp_dict['rank'] = len(v[1]) 
+        tmp_dict['dims'] = [dim.replace('.','_') for dim in v[1]]
+        tmp_dict['rank'] = len(v[1])
         dim_str = tmp_dict['dims'][0]
         if tmp_dict['rank'] > 1:
             for i in range(1, tmp_dict['rank']):
                 dim_toadd = tmp_dict['dims'][i]
                 dim_str += f', {dim_toadd}'
-        tmp_dict['dim_list'] = dim_str 
+        tmp_dict['dim_list'] = dim_str
         datasets_nostr[k] = tmp_dict
 
 
@@ -79,9 +81,9 @@ templ_path_hdf5 = join(fileDir,'templates_hdf5')
 templ_path_front = join(fileDir,'templates_front')
 
 
-files_exclude = ['prefix_hdf5.c', 'prefix_hdf5.h', 'suffix_hdf5.h', 
-                 'prefix_text.c', 'prefix_text.h', 'suffix_text.h', 
-                 'prefix_front.c', 'prefix_front.h', 'suffix_front.h', 
+files_exclude = ['prefix_hdf5.c', 'prefix_hdf5.h', 'suffix_hdf5.h',
+                 'prefix_text.c', 'prefix_text.h', 'suffix_text.h',
+                 'prefix_front.c', 'prefix_front.h', 'suffix_front.h',
                  'prefix_fortran.f90', 'suffix_fortran.f90',
                  'prefix_s_front.h', 'suffix_s_front.h',
                  'templator_front.org', 'templator_hdf5.org', 'templator_text.org']
@@ -122,17 +124,17 @@ for fname in files_funcs_groups:
         with open(join(templ_path,fname), 'r') as f_in :
             with open(join(templ_path,fname_new), 'a') as f_out :
                 for line in f_in :
-                    
+
                     if 'END REPEAT' in line:
 
                         if do_dset:
-                            for dset,params in datasets_nostr.items():                           
+                            for dset,params in datasets_nostr.items():
                                 dset_grname = dset.split('_')[0]
                                 if dset_grname != grname:
-                                    continue         
-                                                        
+                                    continue
+
                                 templine1 = loop_body.replace('$group_dset$', dset)
-                                templine2 = templine1.replace('$group$', grname)  
+                                templine2 = templine1.replace('$group$', grname)
 
                                 templine1 = templine2.replace('$group_dset_dtype$', params['dtype'])
                                 templine2 = templine1
@@ -155,11 +157,11 @@ for fname in files_funcs_groups:
                                     continue
 
                                 templine1 = loop_body.replace('$group_num$', dim)
-                                templine2 = templine1.replace('$group$', grname)                            
-                                f_out.write(templine2)     
+                                templine2 = templine1.replace('$group$', grname)
+                                f_out.write(templine2)
                         else:
                             print('fishy')
-                    
+
                         loop_body = ''
                         subloop = False
                         do_dset = False
@@ -168,7 +170,7 @@ for fname in files_funcs_groups:
 
                     if subloop:
                         loop_body += line
-                
+
                     if 'START REPEAT' in line:
                         if 'GROUP_DSET' in line:
                             do_dset = True
@@ -178,7 +180,7 @@ for fname in files_funcs_groups:
 
                     if '$group_dset' in line and not subloop:
                         for dset,params in datasets_nostr.items():
-                            
+
                             dset_grname = dset.split('_')[0]
                             if dset_grname != grname:
                                 continue
@@ -191,8 +193,8 @@ for fname in files_funcs_groups:
 
                             templine1 = templine2.replace('$group$', grname)
                             templine2 = templine1.replace('$GROUP$', grname.upper())
-                            
-                            f_out.write(templine2)   
+
+                            f_out.write(templine2)
                     elif '$group_num' in line and not subloop:
                         #for dim in dim_variables.keys():
                         for dim in numbers.keys():
@@ -205,16 +207,16 @@ for fname in files_funcs_groups:
 
                             templine1 = templine2.replace('$group$', grname)
                             templine2 = templine1.replace('$GROUP$', grname.upper())
-                            
-                            f_out.write(templine2)     
 
-                    elif '$group$' in line and not subloop: 
+                            f_out.write(templine2)
+
+                    elif '$group$' in line and not subloop:
 
                         templine1 = line.replace('$group$', grname)
                         templine2 = templine1.replace('$GROUP$', grname.upper())
-                        f_out.write(templine2)     
+                        f_out.write(templine2)
 
-                    elif not subloop:        
+                    elif not subloop:
                         f_out.write(line)
 
 
@@ -237,14 +239,15 @@ for fname in files_funcs_dsets:
                     if '$' in line:
 
                         if '$group_dset_dim$' in line:
-                            rc_line = '  if (rc != TREXIO_SUCCESS) return rc;\n'
+                            rc_line = 'if (rc != TREXIO_SUCCESS) return rc;\n'
+                            indentlevel = len(line) - len(line.lstrip())
                             for dim in params['dims']:
                                 if not dim.isdigit():
                                     templine1 = line.replace('$group_dset_dim$', dim)
                                     templine2 = templine1
-                                    if '_read' in templine2 and 'hdf5' in fname:
-                                            templine1 = rc_line
-                                            templine2 += templine1   
+                                    if '_read' in templine2: # and 'hdf5' in fname:
+                                            templine1 = indentlevel*" " + rc_line
+                                            templine2 += templine1
 
                                     f_out.write(templine2)
                             continue
@@ -279,9 +282,9 @@ for fname in files_funcs_dsets:
 
                         templine1 = templine2.replace('$group$', grname)
                         templine2 = templine1.replace('$GROUP$', grname.upper())
-                            
-                        f_out.write(templine2)                
-                    else:        
+
+                        f_out.write(templine2)
+                    else:
                         f_out.write(line)
 
 # build files with functions
@@ -293,7 +296,7 @@ for fname in files_funcs_nums:
         templ_path = templ_path_front
     if '_text' in fname:
         templ_path = templ_path_text
-        
+
     for dim in dim_variables.keys():
     #for dim in numbers.keys():
         grname = dim.split('_')[0]
@@ -306,13 +309,13 @@ for fname in files_funcs_nums:
 
                         templine1 = templine2.replace('$group$', grname)
                         templine2 = templine1.replace('$GROUP$', grname.upper())
-                            
-                        f_out.write(templine2)                
-                    else:        
+
+                        f_out.write(templine2)
+                    else:
                         f_out.write(line)
 
 # build files with $group$ and $group$-based
-for fname in ['def_hdf5.c', 'basic_hdf5.c', 'basic_text_group.c', 
+for fname in ['def_hdf5.c', 'basic_hdf5.c', 'basic_text_group.c',
               'struct_hdf5.h', 'struct_text_group.h'] :
     fname_new = join('populated',f'pop_{fname}')
     if '_hdf5' in fname:
@@ -335,13 +338,13 @@ for fname in ['def_hdf5.c', 'basic_hdf5.c', 'basic_text_group.c',
                     #for num in numbers.keys():
                         templine1 = line.replace('$GROUP_NUM$', num.upper())
                         templine2 = templine1.replace('$group_num$', num)
-                        f_out.write(templine2)                
+                        f_out.write(templine2)
                 elif '$group$' in line or '$GROUP$' in line :
                     for grname in config.keys():
                         templine1 = line.replace('$group$', grname)
                         templine2 = templine1.replace('$GROUP$', grname.upper())
-                        f_out.write(templine2)                
-                else:        
+                        f_out.write(templine2)
+                else:
                     f_out.write(line)
 
 

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -390,8 +390,8 @@ end interface
 ** Template for frontend read/write a number
    
      #+begin_src c :tangle rw_num_front.h
-trexio_exit_code trexio_read_$group_num$(trexio_t* file, int64_t* num);
-trexio_exit_code trexio_write_$group_num$(trexio_t* file, const int64_t num);
+trexio_exit_code trexio_read_$group_num$(trexio_t* const file, int64_t* const num);
+trexio_exit_code trexio_write_$group_num$(trexio_t* const file, const int64_t num);
      #+end_src
    
      #+begin_src c :tangle read_num_front.c
@@ -426,7 +426,7 @@ trexio_exit_code trexio_read_$group_num$(trexio_t* file, int64_t* num) {
    
      #+begin_src c :tangle write_num_front.c
 
-trexio_exit_code trexio_write_$group_num$(trexio_t* file, const int64_t num) {
+trexio_exit_code trexio_write_$group_num$(trexio_t* const file, const int64_t num) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
   if (num  <  0   ) return TREXIO_INVALID_ARG_2;
 
@@ -483,12 +483,12 @@ end interface
 ** Template for frontend read/write a dataset
 
      #+begin_src c :tangle rw_dset_front.h
-trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* file, $group_dset_dtype$* $group_dset$);
-trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* file, const $group_dset_dtype$* $group_dset$);
+trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$);
+trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$);
      #+end_src
    
      #+begin_src c :tangle read_dset_front.c
-trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* file, $group_dset_dtype$* $group_dset$) {
+trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$) {
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if ($group_dset$ == NULL) return TREXIO_INVALID_ARG_2;
     
@@ -540,7 +540,7 @@ trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* file, $group_dset_dt
    
      #+begin_src c :tangle write_dset_front.c
 
-trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* file, const $group_dset_dtype$* $group_dset$) {
+trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$) {
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if ($group_dset$ == NULL) return TREXIO_INVALID_ARG_2;
 

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -493,7 +493,7 @@ trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* file, $group_dset_dt
   if ($group_dset$ == NULL) return TREXIO_INVALID_ARG_2;
     
   trexio_exit_code rc;
-  uint64_t $group_dset_dim$ = -1;
+  uint64_t $group_dset_dim$ = 0;
 
   switch (file->back_end) {
 
@@ -513,7 +513,7 @@ trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* file, $group_dset_dt
 
   if (rc != TREXIO_SUCCESS) return rc;
 
-  if ($group_dset_dim$ <= 0L) return TREXIO_INVALID_NUM;
+  if ($group_dset_dim$ == 0L) return TREXIO_INVALID_NUM;
 
   uint32_t rank = $group_dset_rank$;
   uint64_t dims[$group_dset_rank$] = {$group_dset_dim_list$}; 
@@ -545,7 +545,7 @@ trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* file, const $group_
   if ($group_dset$ == NULL) return TREXIO_INVALID_ARG_2;
 
   trexio_exit_code rc;
-  uint64_t $group_dset_dim$ = -1;
+  uint64_t $group_dset_dim$ = 0;
   switch (file->back_end) {
 
   case TREXIO_TEXT:
@@ -563,7 +563,7 @@ trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* file, const $group_
   }
 
   if (rc != TREXIO_SUCCESS) return rc;
-  if ($group_dset_dim$ <= 0L) return TREXIO_INVALID_NUM;
+  if ($group_dset_dim$ == 0L) return TREXIO_INVALID_NUM;
 
   uint32_t rank = $group_dset_rank$;
   uint64_t dims[$group_dset_rank$] = {$group_dset_dim_list$}; 

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -40,7 +40,6 @@ module trexio
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
 
 #include "trexio.h"
 #include "trexio_s.h"

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -285,7 +285,7 @@ trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(const trexio_t* file, $gr
     return TREXIO_FAILURE;
   }
 
-  for (uint32_t i=0; i<rank; i++){
+  for (uint32_t i=0; i<rank; ++i){
      if (ddims[i] != dims[i]) {
        free(ddims);
        return TREXIO_INVALID_ARG_4;

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -157,7 +157,7 @@ trexio_exit_code trexio_hdf5_finalize(trexio_t* file) {
 
   #+begin_src c :tangle rw_num_hdf5.h
 trexio_exit_code trexio_hdf5_read_$group_num$ (const trexio_t* file, uint64_t* num);
-trexio_exit_code trexio_hdf5_write_$group_num$ (const trexio_t* file, const uint64_t num);
+trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* file, const uint64_t num);
   #+end_src
 
    
@@ -167,15 +167,15 @@ trexio_exit_code trexio_hdf5_read_$group_num$ (const trexio_t* file, uint64_t* n
   assert (file != NULL);
   assert (num  != NULL);
   
-  trexio_hdf5_t* f = (trexio_hdf5_t*) file;
+  const trexio_hdf5_t* f = (const trexio_hdf5_t*) file;
   /* Quit if the dimensioning attribute is missing in the file */
   if (H5Aexists(f->$group$_group, $GROUP_NUM$_NAME) == 0) return TREXIO_FAILURE;
 
   /* Read the nucleus_num attribute of nucleus group */
-  hid_t num_id = H5Aopen(f->$group$_group, $GROUP_NUM$_NAME, H5P_DEFAULT);
+  const hid_t num_id = H5Aopen(f->$group$_group, $GROUP_NUM$_NAME, H5P_DEFAULT);
   if (num_id <= 0) return TREXIO_INVALID_ID;
 
-  herr_t status = H5Aread(num_id, H5T_NATIVE_ULLONG, num);
+  const herr_t status = H5Aread(num_id, H5T_NATIVE_ULLONG, num);
   if (status < 0) return TREXIO_FAILURE;
 
   return TREXIO_SUCCESS;
@@ -184,7 +184,7 @@ trexio_exit_code trexio_hdf5_read_$group_num$ (const trexio_t* file, uint64_t* n
 
  
   #+begin_src c :tangle write_num_hdf5.c
-trexio_exit_code trexio_hdf5_write_$group_num$ (const trexio_t* file, const uint64_t num) {
+trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* file, const uint64_t num) {
 
   assert (file != NULL);
   assert (num > 0L);
@@ -247,7 +247,7 @@ trexio_exit_code trexio_hdf5_write_$group_num$ (const trexio_t* file, const uint
     
    #+begin_src c :tangle rw_dset_hdf5.h
 trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(const trexio_t* file, $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
-trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(const trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
+trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
   #+end_src
 
    #+begin_src c :tangle read_dset_hdf5.c
@@ -256,7 +256,7 @@ trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(const trexio_t* file, $gr
   assert (file != NULL);
   assert ($group_dset$ != NULL);
   
-  trexio_hdf5_t* f = (trexio_hdf5_t*) file;
+  const trexio_hdf5_t* f = (const trexio_hdf5_t*) file;
   
   herr_t status;
   int rrank;
@@ -305,7 +305,7 @@ trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(const trexio_t* file, $gr
     #+end_src
 
    #+begin_src c :tangle write_dset_hdf5.c
-trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(const trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
+trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
 
   assert (file != NULL);
   assert ($group_dset$ != NULL);

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -314,7 +314,7 @@ trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(const trexio_t* file, co
   uint64_t $group_dset_dim$;
   // error handling for rc is added by the generator
   rc = trexio_hdf5_read_$group_dset_dim$(file, &($group_dset_dim$)); 
-  if ($group_dset_dim$ <= 0L) return TREXIO_INVALID_NUM;
+  if ($group_dset_dim$ == 0L) return TREXIO_INVALID_NUM;
 
   trexio_hdf5_t* f = (trexio_hdf5_t*) file; 
 

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -332,7 +332,7 @@ trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, co
   if ( H5LTfind_dataset(f->$group$_group, $GROUP$_$GROUP_DSET$_NAME) != 1) { 
     
     status = H5LTmake_dataset_$group_dset_h5_dtype$ (f->$group$_group, $GROUP$_$GROUP_DSET$_NAME, 
-                                      (int) rank, (hsize_t*) dims, $group_dset$);
+                                      (int) rank, (const hsize_t*) dims, $group_dset$);
     if (status < 0) return TREXIO_FAILURE;
 
   } else {   

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -60,8 +60,8 @@ typedef struct trexio_hdf5_s {
   const char* file_name;
 } trexio_hdf5_t;
 
-trexio_exit_code trexio_hdf5_init(trexio_t* file);
-trexio_exit_code trexio_hdf5_finalize(trexio_t* file);
+trexio_exit_code trexio_hdf5_init(trexio_t* const file);
+trexio_exit_code trexio_hdf5_finalize(trexio_t* const file);
 
   #+end_src
   
@@ -70,9 +70,9 @@ trexio_exit_code trexio_hdf5_finalize(trexio_t* file);
 
   #+begin_src c :tangle basic_hdf5.c
 
-trexio_exit_code trexio_hdf5_init(trexio_t* file) {
+trexio_exit_code trexio_hdf5_init(trexio_t* const file) {
 
-  trexio_hdf5_t* f = (trexio_hdf5_t*) file;
+  trexio_hdf5_t* const f = (trexio_hdf5_t*) file;
 
   /* If file doesn't exist, create it */
   int f_exists = 0;
@@ -131,7 +131,7 @@ trexio_exit_code trexio_hdf5_init(trexio_t* file) {
   return TREXIO_SUCCESS;
 }
 
-trexio_exit_code trexio_hdf5_finalize(trexio_t* file) {
+trexio_exit_code trexio_hdf5_finalize(trexio_t* const file) {
 
   trexio_hdf5_t* f = (trexio_hdf5_t*) file;
 
@@ -156,13 +156,13 @@ trexio_exit_code trexio_hdf5_finalize(trexio_t* file) {
 ** Template for HDF5 read/write a number
 
   #+begin_src c :tangle rw_num_hdf5.h
-trexio_exit_code trexio_hdf5_read_$group_num$ (const trexio_t* file, uint64_t* num);
-trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* file, const uint64_t num);
+trexio_exit_code trexio_hdf5_read_$group_num$ (trexio_t* const file, uint64_t* const num);
+trexio_exit_code trexio_hdf5_write_$group_num$(trexio_t* const file, const uint64_t num);
   #+end_src
 
    
   #+begin_src c :tangle read_num_hdf5.c
-trexio_exit_code trexio_hdf5_read_$group_num$ (const trexio_t* file, uint64_t* num) {
+trexio_exit_code trexio_hdf5_read_$group_num$ (trexio_t* const file, uint64_t* const num) {
 
   assert (file != NULL);
   assert (num  != NULL);
@@ -184,29 +184,39 @@ trexio_exit_code trexio_hdf5_read_$group_num$ (const trexio_t* file, uint64_t* n
 
  
   #+begin_src c :tangle write_num_hdf5.c
-trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* file, const uint64_t num) {
+trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* const file, const uint64_t num) {
 
   assert (file != NULL);
   assert (num > 0L);
  
-  trexio_hdf5_t* f = (trexio_hdf5_t*) file;
-  hid_t num_id;
-  herr_t status;
-  /* Write the dimensioning variables */
-  hid_t dtype = H5Tcopy(H5T_NATIVE_ULLONG);
+  trexio_hdf5_t* const f = (trexio_hdf5_t*) file;
 
   if (H5Aexists(f->$group$_group, $GROUP_NUM$_NAME) == 0) {
    
-    hid_t dspace = H5Screate(H5S_SCALAR);
+    /* Write the dimensioning variables */
+    const hid_t dtype = H5Tcopy(H5T_NATIVE_ULLONG);
+    const hid_t dspace = H5Screate(H5S_SCALAR);
 
-    num_id = H5Acreate(f->$group$_group, $GROUP_NUM$_NAME, dtype, dspace,
+    const hid_t num_id = H5Acreate(f->$group$_group, $GROUP_NUM$_NAME, dtype, dspace,
                      H5P_DEFAULT, H5P_DEFAULT);
-    if (num_id <= 0) return TREXIO_INVALID_ID;
+    if (num_id <= 0) {
+      H5Sclose(dspace);
+      H5Tclose(dtype);
+      return TREXIO_INVALID_ID;
+    }
   
-    status = H5Awrite(num_id, dtype, &(num));
-    if (status < 0) return TREXIO_FAILURE;
+    const herr_t status = H5Awrite(num_id, dtype, &(num));
+    if (status < 0) {
+      H5Aclose(num_id);
+      H5Sclose(dspace);
+      H5Tclose(dtype);
+      return TREXIO_FAILURE;
+    }
 
     H5Sclose(dspace);
+    H5Aclose(num_id);
+    H5Tclose(dtype);
+    return TREXIO_SUCCESS;
     
   } else {
 
@@ -219,24 +229,24 @@ trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* file, const uint64_t n
       if (infile_num != 0) {
         printf("%lu -> %lu %s \n", num, infile_num, 
 	       "This variable already exists. Overwriting it is not supported");
-        H5Tclose(dtype);
         return TREXIO_FAILURE;
 
       } else {
     
-        num_id = H5Aopen(f->$group$_group, $GROUP_NUM$_NAME, H5P_DEFAULT);
+        const hid_t dtype = H5Tcopy(H5T_NATIVE_ULLONG);
+        const hid_t num_id = H5Aopen(f->$group$_group, $GROUP_NUM$_NAME, H5P_DEFAULT);
         if (num_id <= 0) return TREXIO_INVALID_ID;
        
-        status = H5Awrite(num_id, dtype, &(num));
+        const herr_t status = H5Awrite(num_id, dtype, &(num));
         if (status < 0) return TREXIO_FAILURE;
 
+        H5Aclose(num_id);
+        H5Tclose(dtype);
       }
     }
+    return TREXIO_SUCCESS;
   }
 
-  H5Aclose(num_id);
-  H5Tclose(dtype);
-  return TREXIO_SUCCESS;
   
 }
     #+end_src
@@ -246,12 +256,12 @@ trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* file, const uint64_t n
 
     
    #+begin_src c :tangle rw_dset_hdf5.h
-trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(const trexio_t* file, $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
-trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
+trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims);
+trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
   #+end_src
 
    #+begin_src c :tangle read_dset_hdf5.c
-trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(const trexio_t* file, $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
+trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims) {
 
   assert (file != NULL);
   assert ($group_dset$ != NULL);
@@ -305,7 +315,7 @@ trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(const trexio_t* file, $gr
     #+end_src
 
    #+begin_src c :tangle write_dset_hdf5.c
-trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
+trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
 
   assert (file != NULL);
   assert ($group_dset$ != NULL);

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -328,10 +328,10 @@ trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, co
 
   trexio_hdf5_t* f = (trexio_hdf5_t*) file; 
 
-  herr_t status;
   if ( H5LTfind_dataset(f->$group$_group, $GROUP$_$GROUP_DSET$_NAME) != 1) { 
     
-    status = H5LTmake_dataset_$group_dset_h5_dtype$ (f->$group$_group, $GROUP$_$GROUP_DSET$_NAME, 
+    const herr_t status =
+      H5LTmake_dataset_$group_dset_h5_dtype$ (f->$group$_group, $GROUP$_$GROUP_DSET$_NAME, 
                                       (int) rank, (const hsize_t*) dims, $group_dset$);
     if (status < 0) return TREXIO_FAILURE;
 
@@ -340,7 +340,9 @@ trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, co
     hid_t dset_id = H5Dopen(f->$group$_group, $GROUP$_$GROUP_DSET$_NAME, H5P_DEFAULT);
     if (dset_id <= 0) return TREXIO_INVALID_ID;
     
-    status = H5Dwrite(dset_id, H5T_NATIVE_$GROUP_DSET_H5_DTYPE$, H5S_ALL, H5S_ALL, H5P_DEFAULT, $group_dset$);
+    const herr_t status =
+      H5Dwrite(dset_id, H5T_NATIVE_$GROUP_DSET_H5_DTYPE$, H5S_ALL, H5S_ALL,
+               H5P_DEFAULT, $group_dset$);
     
     H5Dclose(dset_id);
     if (status < 0) return TREXIO_FAILURE;

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -217,7 +217,7 @@ trexio_exit_code trexio_hdf5_write_$group_num$ (const trexio_t* file, const uint
     if (infile_num != num) {
 
       if (infile_num != 0) {
-        printf("%ld -> %ld %s \n", num, infile_num, 
+        printf("%lu -> %lu %s \n", num, infile_num, 
 	       "This variable already exists. Overwriting it is not supported");
         H5Tclose(dtype);
         return TREXIO_FAILURE;

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -315,7 +315,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
     uint64_t size_$group_dset$ = 0;
     if ($group$->rank_$group_dset$ != 0) size_$group_dset$ = 1;
 
-    for (unsigned int i=0; i<$group$->rank_$group_dset$; i++){
+    for (unsigned int i=0; i<$group$->rank_$group_dset$; ++i){
 
       unsigned int j=-1;
       rc = fscanf(f, "%s %u", buffer, &j);
@@ -392,7 +392,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
       return NULL;
     }
     
-    for (uint64_t i=0 ; i<size_$group_dset$ ; i++) {
+    for (uint64_t i=0 ; i<size_$group_dset$ ; ++i) {
       rc = fscanf(f, "%$group_dset_std_dtype$", &($group$->$group_dset$[i]));
       assert(!(rc != 1));
       if (rc != 1) {
@@ -465,7 +465,7 @@ trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
   uint64_t size_$group_dset$ = 0;
   if ($group$->rank_$group_dset$ != 0) size_$group_dset$ = 1;
 
-  for (unsigned int i=0; i<$group$->rank_$group_dset$; i++){
+  for (unsigned int i=0; i<$group$->rank_$group_dset$; ++i){
     fprintf(f, "dims_$group_dset$ %d  %ld\n", i, $group$->dims_$group_dset$[i]);
     size_$group_dset$ *= $group$->dims_$group_dset$[i];
   } 
@@ -483,7 +483,7 @@ trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
   /* Write arrays */
   
   fprintf(f, "$group_dset$\n");
-  for (uint64_t i=0 ; i<size_$group_dset$ ; i++) {
+  for (uint64_t i=0 ; i<size_$group_dset$ ; ++i) {
     fprintf(f, "%$group_dset_std_dtype$\n", $group$->$group_dset$[i]);
   }
 
@@ -596,12 +596,12 @@ trexio_exit_code trexio_text_read_$group_dset$(const trexio_t* file, $group_dset
   if (rank != $group$->rank_$group_dset$) return TREXIO_INVALID_ARG_3;
   
   uint64_t dim_size = 1;
-  for (unsigned int i=0; i<rank; i++){
+  for (unsigned int i=0; i<rank; ++i){
     if (dims[i] != $group$->dims_$group_dset$[i]) return TREXIO_INVALID_ARG_4;
     dim_size *= dims[i];
   }
 
-  for (uint64_t i=0 ; i<dim_size ; i++) {
+  for (uint64_t i=0 ; i<dim_size ; ++i) {
     $group_dset$[i] = $group$->$group_dset$[i];
   }
 
@@ -627,14 +627,14 @@ trexio_exit_code trexio_text_write_$group_dset$(const trexio_t* file, const $gro
   $group$->rank_$group_dset$ = rank;
   
   uint64_t dim_size = 1;
-  for (unsigned int i=0; i<$group$->rank_$group_dset$; i++){
+  for (unsigned int i=0; i<$group$->rank_$group_dset$; ++i){
     $group$->dims_$group_dset$[i] = dims[i];
     dim_size *= dims[i];
   }
 
   $group$->$group_dset$ = CALLOC(dim_size, $group_dset_dtype$);
 
-  for (uint64_t i=0 ; i<dim_size ; i++) {
+  for (uint64_t i=0 ; i<dim_size ; ++i) {
     $group$->$group_dset$[i] = $group_dset$[i];
   }
   
@@ -703,7 +703,7 @@ rdm_t* trexio_text_read_rdm(trexio_text_t* file) {
     assert (rc == 1);
     assert (strcmp(buffer, "one_e") == 0);
     
-    for (uint64_t i=0 ; i<rdm->dim_one_e; i++) {
+    for (uint64_t i=0 ; i<rdm->dim_one_e; ++i) {
       rc = fscanf(f, "%lf", &(rdm->one_e[i]));
       assert (rc == 1);
     }
@@ -760,7 +760,7 @@ trexio_exit_code trexio_text_flush_rdm(const trexio_text_t* file) {
 
   /* Write arrays */
   fprintf(f, "one_e\n");
-  for (uint64_t i=0 ; i< rdm->dim_one_e; i++) {
+  for (uint64_t i=0 ; i< rdm->dim_one_e; ++i) {
     fprintf(f, "%lf\n", rdm->one_e[i]);
   }
 
@@ -833,7 +833,7 @@ trexio_exit_code trexio_text_read_rdm_one_e(const trexio_t* file, double* one_e,
 
   if (dim_one_e != rdm->dim_one_e) return TREXIO_INVALID_ARG_3;
 
-  for (uint64_t i=0 ; i<dim_one_e ; i++) {
+  for (uint64_t i=0 ; i<dim_one_e ; ++i) {
     one_e[i] = rdm->one_e[i];
   }
 
@@ -850,7 +850,7 @@ trexio_exit_code trexio_text_write_rdm_one_e(const trexio_t* file, const double*
   if (rdm == NULL) return TREXIO_FAILURE;
   
   rdm->dim_one_e = dim_one_e;
-  for (uint64_t i=0 ; i<dim_one_e ; i++) {
+  for (uint64_t i=0 ; i<dim_one_e ; ++i) {
     rdm->one_e[i] = one_e[i];
   }
   
@@ -885,11 +885,11 @@ trexio_exit_code trexio_text_buffered_read_rdm_two_e(const trexio_t* file, const
   FILE* f = fopen(rdm->two_e_file_name, "r");
   if (f == NULL) return TREXIO_END;
 
-  const uint64_t line_length = 64;
+  const uint64_t line_length = 64L;
   fseek(f, (long) offset * line_length, SEEK_SET);
   
   int rc;
-  for (uint64_t i=0 ; i<size ; i++) {
+  for (uint64_t i=0 ; i<size ; ++i) {
     rc = fscanf(f, "%9ld %9ld %9ld %9ld %24le\n",
            &index[4*i], 
            &index[4*i+1], 
@@ -921,11 +921,11 @@ trexio_exit_code trexio_text_buffered_write_rdm_two_e(const trexio_t* file, cons
   FILE* f = fopen(rdm->two_e_file_name, "w");
   if (f == NULL) return TREXIO_FAILURE;
 
-  const uint64_t line_length = 64;
+  const uint64_t line_length = 64L;
   fseek(f, (long) offset * line_length, SEEK_SET);
   
   int rc;
-  for (uint64_t i=0 ; i<size ; i++) {
+  for (uint64_t i=0 ; i<size ; ++i) {
     rc = fprintf(f, "%9ld %9ld %9ld %9ld %24le\n",
            index[4*i], 
            index[4*i+1], 

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -149,7 +149,7 @@ trexio_exit_code trexio_text_init(trexio_t* const file) {
   }
  
   strncpy (file_name, file->file_name, str_size);
-  strcat (file_name, lock_file_name);
+  strncat (file_name, lock_file_name, strlen(lock_file_name));
 
   f->lock_file = open(file_name,O_WRONLY|O_CREAT|O_TRUNC, 0644);
   FREE(file_name);
@@ -268,7 +268,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* const file) {
   }
 
   strncpy (file_name, file->parent.file_name, str_size);
-  strcat (file_name, $group$_file_name);
+  strncat (file_name, $group$_file_name, strlen($group$_file_name));
 
   /* If the file exists, read it */
   FILE* f = fopen(file_name,"r");
@@ -671,7 +671,7 @@ rdm_t* trexio_text_read_rdm(trexio_text_t* const file) {
 
   assert (file_name != NULL);
   strncpy (file_name, file->parent.file_name, str_size);
-  strcat (file_name, rdm_file_name);
+  strncat (file_name, rdm_file_name, strlen(rdm_file_name));
 
   /* If the file exists, read it */
   FILE* f = fopen(file_name,"r");

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -716,7 +716,7 @@ rdm_t* trexio_text_read_rdm(trexio_text_t* file) {
     
     rc = fscanf(f, "%1023s", buffer);
     assert (rc == 1);
-    size_t str_size = strlen(buffer);
+    str_size = strlen(buffer);
     rdm->two_e_file_name = CALLOC(str_size,char);
     strncpy(rdm->two_e_file_name, buffer, str_size);
     
@@ -888,9 +888,8 @@ trexio_exit_code trexio_text_buffered_read_rdm_two_e(const trexio_t* file, const
   const uint64_t line_length = 64L;
   fseek(f, (long) offset * line_length, SEEK_SET);
   
-  int rc;
   for (uint64_t i=0 ; i<size ; ++i) {
-    rc = fscanf(f, "%9ld %9ld %9ld %9ld %24le\n",
+    int rc = fscanf(f, "%9ld %9ld %9ld %9ld %24le\n",
            &index[4*i], 
            &index[4*i+1], 
            &index[4*i+2], 
@@ -922,9 +921,8 @@ trexio_exit_code trexio_text_buffered_write_rdm_two_e(const trexio_t* file, cons
   const uint64_t line_length = 64L;
   fseek(f, (long) offset * line_length, SEEK_SET);
   
-  int rc;
   for (uint64_t i=0 ; i<size ; ++i) {
-    rc = fprintf(f, "%9ld %9ld %9ld %9ld %24le\n",
+    int rc = fprintf(f, "%9ld %9ld %9ld %9ld %24le\n",
            index[4*i], 
            index[4*i+1], 
            index[4*i+2], 

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -281,6 +281,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
     size_t sz = ftell(f);
     fseek(f, 0L, SEEK_SET);
 
+    sz = (sz < 1024) ? (1024) : (sz);
     char* buffer = CALLOC(sz, char);
     if (buffer == NULL) {
       FREE(file_name);
@@ -294,7 +295,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
 
     // START REPEAT GROUP_DSET
 
-    rc = fscanf(f, "%s", buffer);
+    rc = fscanf(f, "%1023s", buffer);
     if ((rc != 1) || (strcmp(buffer, "rank_$group_dset$") != 0)) {
       FREE(buffer);
       FREE(file_name);
@@ -312,14 +313,15 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
       return NULL;
     }
 
-    // workaround for the case of missing blocks in the file
+    /* workaround for the case of missing blocks in the file */
     uint64_t size_$group_dset$ = 0;
     if ($group$->rank_$group_dset$ != 0) size_$group_dset$ = 1;
 
     for (unsigned int i=0; i<$group$->rank_$group_dset$; ++i){
 
-      unsigned int j=-1;
-      rc = fscanf(f, "%s %u", buffer, &j);
+      unsigned int j=0;
+
+      rc = fscanf(f, "%1023s %u", buffer, &j);
       if ((rc != 2) || (strcmp(buffer, "dims_$group_dset$") != 0) || (j!=i)) {
         FREE(buffer);
         FREE(file_name);
@@ -346,7 +348,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
     // START REPEAT GROUP_NUM
 
     /* Read data */
-    rc = fscanf(f, "%s", buffer);
+    rc = fscanf(f, "%1023s", buffer);
     assert(!((rc != 1) || (strcmp(buffer, "$group_num$") != 0)));
     if ((rc != 1) || (strcmp(buffer, "$group_num$") != 0)) {
       FREE(buffer);
@@ -381,7 +383,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
       return NULL;
     }
  
-    rc = fscanf(f, "%s", buffer);
+    rc = fscanf(f, "%1023s", buffer);
     assert(!((rc != 1) || (strcmp(buffer, "$group_dset$") != 0)));
     if ((rc != 1) || (strcmp(buffer, "$group_dset$") != 0)) {
       FREE(buffer);
@@ -454,7 +456,7 @@ trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
 
   FILE* f = $group$->file;
   assert (f != NULL);
-  rewind(f);
+  fseek(f, 0L, SEEK_SET);
 
   /* Write the dimensioning variables */ 
  
@@ -684,11 +686,12 @@ rdm_t* trexio_text_read_rdm(trexio_text_t* file) {
     fseek(f, 0L, SEEK_END);
     size_t sz = ftell(f);
     fseek(f, 0L, SEEK_SET);
+    sz = (sz < 1024) ? (1024) : (sz);
     char* buffer = CALLOC(sz, char);
     
     /* Read the dimensioning variables */
     int rc;
-    rc = fscanf(f, "%s", buffer);
+    rc = fscanf(f, "%1023s", buffer);
     assert (rc == 1);
     assert (strcmp(buffer, "dim_one_e") == 0);
     
@@ -700,7 +703,7 @@ rdm_t* trexio_text_read_rdm(trexio_text_t* file) {
     assert (rdm->one_e != NULL);
     
     /* Read one_e */
-    rc = fscanf(f, "%s", buffer);
+    rc = fscanf(f, "%1023s", buffer);
     assert (rc == 1);
     assert (strcmp(buffer, "one_e") == 0);
     
@@ -710,11 +713,11 @@ rdm_t* trexio_text_read_rdm(trexio_text_t* file) {
     }
     
     /* Read two_e */
-    rc = fscanf(f, "%s", buffer);
+    rc = fscanf(f, "%1023s", buffer);
     assert (rc == 1);
     assert (strcmp(buffer, "two_e_file_name") == 0);
     
-    rc = fscanf(f, "%s", buffer);
+    rc = fscanf(f, "%1023s", buffer);
     assert (rc == 1);
     size_t str_size = strlen(buffer);
     rdm->two_e_file_name = CALLOC(str_size,char);
@@ -754,7 +757,7 @@ trexio_exit_code trexio_text_flush_rdm(const trexio_text_t* file) {
 
   FILE* f = rdm->file;
   assert (f != NULL);
-  rewind(f);
+  fseek(f, 0L, SEEK_SET);
 
   /* Write the dimensioning variables */
   fprintf(f, "num %lu\n", rdm->dim_one_e);
@@ -925,7 +928,7 @@ trexio_exit_code trexio_text_buffered_write_rdm_two_e(const trexio_t* file, cons
   
   int rc;
   for (uint64_t i=0 ; i<size ; ++i) {
-    rc = fprintf(f, "%9lu %9lu %9lu %9lu %24le\n",
+    rc = fprintf(f, "%9ld %9ld %9ld %9ld %24le\n",
            index[4*i], 
            index[4*i+1], 
            index[4*i+2], 

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -460,14 +460,14 @@ trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
  
   // START REPEAT GROUP_DSET
  
-  fprintf(f, "rank_$group_dset$ %d\n", $group$->rank_$group_dset$);
+  fprintf(f, "rank_$group_dset$ %u\n", $group$->rank_$group_dset$);
 
   // workaround for the case of missing blocks in the file
   uint64_t size_$group_dset$ = 0;
   if ($group$->rank_$group_dset$ != 0) size_$group_dset$ = 1;
 
   for (unsigned int i=0; i<$group$->rank_$group_dset$; ++i){
-    fprintf(f, "dims_$group_dset$ %d  %ld\n", i, $group$->dims_$group_dset$[i]);
+    fprintf(f, "dims_$group_dset$ %u  %lu\n", i, $group$->dims_$group_dset$[i]);
     size_$group_dset$ *= $group$->dims_$group_dset$[i];
   } 
 
@@ -475,7 +475,7 @@ trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
 
   // START REPEAT GROUP_NUM
 
-  fprintf(f, "$group_num$ %ld\n", $group$->$group_num$);
+  fprintf(f, "$group_num$ %lu\n", $group$->$group_num$);
 
   // END REPEAT GROUP_NUM
 
@@ -757,7 +757,7 @@ trexio_exit_code trexio_text_flush_rdm(const trexio_text_t* file) {
   rewind(f);
 
   /* Write the dimensioning variables */
-  fprintf(f, "num %ld\n", rdm->dim_one_e);
+  fprintf(f, "num %lu\n", rdm->dim_one_e);
 
   /* Write arrays */
   fprintf(f, "one_e\n");
@@ -925,7 +925,7 @@ trexio_exit_code trexio_text_buffered_write_rdm_two_e(const trexio_t* file, cons
   
   int rc;
   for (uint64_t i=0 ; i<size ; ++i) {
-    rc = fprintf(f, "%9ld %9ld %9ld %9ld %24le\n",
+    rc = fprintf(f, "%9lu %9lu %9lu %9lu %24le\n",
            index[4*i], 
            index[4*i+1], 
            index[4*i+2], 

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -78,12 +78,12 @@
     #+begin_src c :tangle struct_text_group_dset.h
 
 typedef struct $group$_s {
+  uint64_t $group_num$;
   FILE*    file;
   $group_dset_dtype$*  $group_dset$;
-  uint64_t $group_num$;
-  uint64_t dims_$group_dset$[16];
   uint32_t rank_$group_dset$;
-  int      to_flush;
+  uint32_t to_flush;
+  uint64_t dims_$group_dset$[16];
 } $group$_t;
 
     #+end_src
@@ -93,18 +93,19 @@ typedef struct $group$_s {
     #+begin_src c :tangle struct_text_group.h
 
 typedef struct rdm_s {
-  FILE*    file;
   uint64_t dim_one_e;
+  uint32_t to_flush;
+  uint32_t padding;
   double*  one_e;
+  FILE*    file;
   char*    two_e_file_name;
-  int      to_flush;
 } rdm_t;
 
 typedef struct trexio_text_s {
   trexio_t   parent ;
-  int        lock_file;
   $group$_t* $group$;
   rdm_t*      rdm;
+  int        lock_file;
 } trexio_text_t;
 
     #+end_src

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -204,12 +204,11 @@ trexio_exit_code trexio_text_unlock(trexio_t* file) {
 
   struct flock fl;
 
-  fl.l_type   = F_WRLCK;
+  fl.l_type   = F_UNLCK;   
   fl.l_whence = SEEK_SET;
   fl.l_start  = 0;         
   fl.l_len    = 0;         
   fl.l_pid    = getpid();  
-  fl.l_type   = F_UNLCK;   
   fcntl(f->lock_file, F_SETLK, &fl);
     
   close(f->lock_file);
@@ -493,7 +492,7 @@ trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
   // END REPEAT GROUP_DSET
 
   fflush(f);
-  file->$group$->to_flush = 0;
+  $group$->to_flush = 0;
   return TREXIO_SUCCESS;
 }
    #+end_src
@@ -510,10 +509,8 @@ trexio_exit_code trexio_text_free_$group$(trexio_text_t* file);
 trexio_exit_code trexio_text_free_$group$(trexio_text_t* file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
   
-  trexio_exit_code rc;
-
   if (file->parent.mode != 'r') {
-    rc = trexio_text_flush_$group$(file);
+    trexio_exit_code rc = trexio_text_flush_$group$(file);
     if (rc != TREXIO_SUCCESS) return TREXIO_FAILURE;
   }
 
@@ -772,7 +769,7 @@ trexio_exit_code trexio_text_flush_rdm(const trexio_text_t* file) {
   fprintf(f, "%s\n", rdm->two_e_file_name);
 
   fflush(f);
-  file->rdm->to_flush = 0;
+  rdm->to_flush = 0;
   return TREXIO_SUCCESS;
 }
    #+end_src
@@ -789,9 +786,8 @@ trexio_exit_code trexio_text_free_rdm(trexio_text_t* file);
 trexio_exit_code trexio_text_free_rdm(trexio_text_t* file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
   
-  trexio_exit_code rc;
   if (file->parent.mode != 'r') {
-    rc = trexio_text_flush_rdm(file);
+    trexio_exit_code rc = trexio_text_flush_rdm(file);
     if (rc != TREXIO_SUCCESS) return TREXIO_FAILURE;
   }
 

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -113,14 +113,14 @@ typedef struct trexio_text_s {
 *** Init/deinit functions (constant part)
 
     #+begin_src c :tangle basic_text.h
-trexio_exit_code trexio_text_init(trexio_t* file);
+trexio_exit_code trexio_text_init(trexio_t* const file);
     #+end_src
   
     #+begin_src c :tangle basic_text.c
-trexio_exit_code trexio_text_init(trexio_t* file) {
+trexio_exit_code trexio_text_init(trexio_t* const file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
 
-  trexio_text_t* f = (trexio_text_t*) file;
+  trexio_text_t* const f = (trexio_text_t*) file;
 
   /* Put all pointers to NULL but leave parent untouched */
   memset(&(f->parent)+1,0,sizeof(trexio_text_t)-sizeof(trexio_t));
@@ -163,14 +163,14 @@ trexio_exit_code trexio_text_init(trexio_t* file) {
     #+end_src
 
     #+begin_src c :tangle basic_text.h
-trexio_exit_code trexio_text_lock(trexio_t* file);
+trexio_exit_code trexio_text_lock(trexio_t* const file);
     #+end_src
   
     #+begin_src c :tangle basic_text.c
-trexio_exit_code trexio_text_lock(trexio_t* file) {
+trexio_exit_code trexio_text_lock(trexio_t* const file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
 
-  trexio_text_t* f = (trexio_text_t*) file;
+  trexio_text_t* const f = (trexio_text_t*) file;
 
   struct flock fl;
   
@@ -189,18 +189,18 @@ trexio_exit_code trexio_text_lock(trexio_t* file) {
 
     
     #+begin_src c :tangle basic_text.h
-trexio_exit_code trexio_text_finalize(trexio_t* file);
+trexio_exit_code trexio_text_finalize(trexio_t* const file);
     #+end_src
 
     #+begin_src c :tangle basic_text.h
-trexio_exit_code trexio_text_unlock(trexio_t* file);
+trexio_exit_code trexio_text_unlock(trexio_t* const file);
     #+end_src
     
     #+begin_src c :tangle basic_text.c
-trexio_exit_code trexio_text_unlock(trexio_t* file) {
+trexio_exit_code trexio_text_unlock(trexio_t* const file) {
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
 
-  trexio_text_t* f = (trexio_text_t*) file;
+  trexio_text_t* const f = (trexio_text_t*) file;
 
   struct flock fl;
 
@@ -220,7 +220,7 @@ trexio_exit_code trexio_text_unlock(trexio_t* file) {
 *** Init/deinit functions (templated part)
  
     #+begin_src c :tangle basic_text_group.c
-trexio_exit_code trexio_text_finalize(trexio_t* file) {
+trexio_exit_code trexio_text_finalize(trexio_t* const file) {
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
 
   trexio_exit_code rc;
@@ -239,12 +239,11 @@ trexio_exit_code trexio_text_finalize(trexio_t* file) {
 *** Template for text read struct
 
     #+begin_src c :tangle read_group_text.h
-$group$_t* trexio_text_read_$group$(trexio_text_t* file);
+$group$_t* trexio_text_read_$group$(trexio_text_t* const file);
     #+end_src
 
     #+begin_src c :tangle read_group_text.c
-
-$group$_t* trexio_text_read_$group$(trexio_text_t* file) {
+$group$_t* trexio_text_read_$group$(trexio_text_t* const file) {
   if (file == NULL) return NULL;
 
   /* If the data structure exists, return it */
@@ -438,11 +437,11 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* file) {
 *** Template for text flush struct
 
     #+begin_src c :tangle flush_group_text.h
-trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file);
+trexio_exit_code trexio_text_flush_$group$(trexio_text_t* const file);
     #+end_src
 
     #+begin_src c :tangle flush_group_text.c
-trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
+trexio_exit_code trexio_text_flush_$group$(trexio_text_t* const file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
 
   if (file->parent.mode == 'r') return TREXIO_READONLY;
@@ -502,11 +501,11 @@ trexio_exit_code trexio_text_flush_$group$(const trexio_text_t* file) {
      Memory is allocated when reading. The following function frees memory.
     
     #+begin_src c :tangle free_group_text.h
-trexio_exit_code trexio_text_free_$group$(trexio_text_t* file);
+trexio_exit_code trexio_text_free_$group$(trexio_text_t* const file);
     #+end_src
     
     #+begin_src c :tangle free_group_text.c
-trexio_exit_code trexio_text_free_$group$(trexio_text_t* file) {
+trexio_exit_code trexio_text_free_$group$(trexio_text_t* const file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
   
   if (file->parent.mode != 'r') {
@@ -538,12 +537,12 @@ trexio_exit_code trexio_text_free_$group$(trexio_text_t* file) {
 *** Template for read/write the $group_num$ attribute
 
     #+begin_src c :tangle rw_num_text.h
-trexio_exit_code trexio_text_read_$group_num$(const trexio_t* file, uint64_t* num);
-trexio_exit_code trexio_text_write_$group_num$(const trexio_t* file, const uint64_t num);
+trexio_exit_code trexio_text_read_$group_num$ (trexio_t* const file, uint64_t* const num);
+trexio_exit_code trexio_text_write_$group_num$(trexio_t* const file, const uint64_t num);
    #+end_src
 
     #+begin_src c :tangle read_num_text.c
-trexio_exit_code trexio_text_read_$group_num$(const trexio_t* file, uint64_t* num) {
+trexio_exit_code trexio_text_read_$group_num$(trexio_t* const file, uint64_t* const num) {
 
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if (num   == NULL) return TREXIO_INVALID_ARG_2;
@@ -551,7 +550,7 @@ trexio_exit_code trexio_text_read_$group_num$(const trexio_t* file, uint64_t* nu
   $group$_t* $group$ = trexio_text_read_$group$((trexio_text_t*) file);
   if ($group$ == NULL) return TREXIO_FAILURE;
 
-  /**/ *num = $group$->$group_num$;
+  *num = $group$->$group_num$;
 
   return TREXIO_SUCCESS;
 }
@@ -559,7 +558,7 @@ trexio_exit_code trexio_text_read_$group_num$(const trexio_t* file, uint64_t* nu
 
    #+begin_src c :tangle write_num_text.c
  
-trexio_exit_code trexio_text_write_$group_num$(const trexio_t* file, const uint64_t num) {
+trexio_exit_code trexio_text_write_$group_num$(trexio_t* const file, const uint64_t num) {
 
   if (file == NULL) return TREXIO_INVALID_ARG_1;
 
@@ -580,17 +579,17 @@ trexio_exit_code trexio_text_write_$group_num$(const trexio_t* file, const uint6
      The ~dset~ array is assumed allocated with the appropriate size.
     
     #+begin_src c :tangle rw_dset_text.h
-trexio_exit_code trexio_text_read_$group_dset$(const trexio_t* file, $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
-trexio_exit_code trexio_text_write_$group_dset$(const trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
+trexio_exit_code trexio_text_read_$group_dset$ (trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims);
+trexio_exit_code trexio_text_write_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
    #+end_src
 
     #+begin_src c :tangle read_dset_text.c
-trexio_exit_code trexio_text_read_$group_dset$(const trexio_t* file, $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
+trexio_exit_code trexio_text_read_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims) {
 
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if ($group_dset$ == NULL) return TREXIO_INVALID_ARG_2;
 
-  $group$_t* $group$ = trexio_text_read_$group$((trexio_text_t*) file);
+  $group$_t* const $group$ = trexio_text_read_$group$((trexio_text_t*) file);
   if ($group$ == NULL) return TREXIO_FAILURE;
 
   if (rank != $group$->rank_$group_dset$) return TREXIO_INVALID_ARG_3;
@@ -610,14 +609,13 @@ trexio_exit_code trexio_text_read_$group_dset$(const trexio_t* file, $group_dset
    #+end_src
 
    #+begin_src c :tangle write_dset_text.c
- 
-trexio_exit_code trexio_text_write_$group_dset$(const trexio_t* file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
+trexio_exit_code trexio_text_write_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
   if (file  == NULL)  return TREXIO_INVALID_ARG_1;
   if ($group_dset$ == NULL)  return TREXIO_INVALID_ARG_2;
 
   if (file->mode == 'r') return TREXIO_READONLY;
 
-  $group$_t* $group$ = trexio_text_read_$group$((trexio_text_t*) file);
+  $group$_t* const $group$ = trexio_text_read_$group$((trexio_text_t*) file);
   if ($group$ == NULL) return TREXIO_FAILURE;
   
   if ($group$->$group_dset$ != NULL) {
@@ -648,17 +646,17 @@ trexio_exit_code trexio_text_write_$group_dset$(const trexio_t* file, const $gro
 **** Read the complete struct
 
     #+begin_src c :tangle rdm_text.h
-rdm_t* trexio_text_read_rdm(trexio_text_t* file);
+rdm_t* trexio_text_read_rdm(trexio_text_t* const file);
     #+end_src
     
     #+begin_src c :tangle rdm_text.c
-rdm_t* trexio_text_read_rdm(trexio_text_t* file) {
+rdm_t* trexio_text_read_rdm(trexio_text_t* const file) {
   if (file  == NULL) return NULL;
 
   if (file->rdm != NULL) return file->rdm;
 
   /* Allocate the data structure */
-  rdm_t* rdm = MALLOC(rdm_t);
+  rdm_t* const rdm = MALLOC(rdm_t);
   assert (rdm != NULL);
 
   rdm->one_e           = NULL;
@@ -738,16 +736,16 @@ rdm_t* trexio_text_read_rdm(trexio_text_t* file) {
 **** Flush the complete struct
 
     #+begin_src c :tangle rdm_text.h
-trexio_exit_code trexio_text_flush_rdm(const trexio_text_t* file);
+trexio_exit_code trexio_text_flush_rdm(trexio_text_t* const file);
     #+end_src
 
     #+begin_src c :tangle rdm_text.c
-trexio_exit_code trexio_text_flush_rdm(const trexio_text_t* file) {
+trexio_exit_code trexio_text_flush_rdm(trexio_text_t* const file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
 
   if (file->parent.mode == 'r') return TREXIO_READONLY;
 
-  rdm_t* rdm = file->rdm;
+  rdm_t* const rdm = file->rdm;
   if (rdm == NULL) return TREXIO_SUCCESS;
 
   if (rdm->to_flush == 0) return TREXIO_SUCCESS;
@@ -779,11 +777,11 @@ trexio_exit_code trexio_text_flush_rdm(const trexio_text_t* file) {
      Memory is allocated when reading. The followig function frees memory.
     
     #+begin_src c :tangle rdm_text.h
-trexio_exit_code trexio_text_free_rdm(trexio_text_t* file);
+trexio_exit_code trexio_text_free_rdm(trexio_text_t* const file);
     #+end_src
     
     #+begin_src c :tangle rdm_text.c
-trexio_exit_code trexio_text_free_rdm(trexio_text_t* file) {
+trexio_exit_code trexio_text_free_rdm(trexio_text_t* const file) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
   
   if (file->parent.mode != 'r') {
@@ -791,7 +789,7 @@ trexio_exit_code trexio_text_free_rdm(trexio_text_t* file) {
     if (rc != TREXIO_SUCCESS) return TREXIO_FAILURE;
   }
 
-  rdm_t* rdm = file->rdm;
+  rdm_t* const rdm = file->rdm;
   if (rdm == NULL) return TREXIO_SUCCESS;
 
   if (rdm->file != NULL) {
@@ -818,17 +816,27 @@ trexio_exit_code trexio_text_free_rdm(trexio_text_t* file) {
      The ~one_e~ array is assumed allocated with the appropriate size.
     
     #+begin_src c :tangle rdm_text.h
-trexio_exit_code trexio_text_read_rdm_one_e(const trexio_t* file, double* one_e, const uint64_t dim_one_e);
-trexio_exit_code trexio_text_write_rdm_one_e(const trexio_t* file, const double* one_e, const uint64_t dim_one_e);
+trexio_exit_code
+trexio_text_read_rdm_one_e(trexio_t* const file,
+                           double* const one_e,
+                           const uint64_t dim_one_e);
+
+trexio_exit_code
+trexio_text_write_rdm_one_e(trexio_t* const file,
+                            const double* one_e,
+                            const uint64_t dim_one_e);
    #+end_src
 
     #+begin_src c :tangle rdm_text.c
-trexio_exit_code trexio_text_read_rdm_one_e(const trexio_t* file, double* one_e, const uint64_t dim_one_e) {
-
+trexio_exit_code
+trexio_text_read_rdm_one_e(trexio_t* const file,
+                           double* const one_e,
+                           const uint64_t dim_one_e)
+{
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if (one_e == NULL) return TREXIO_INVALID_ARG_2;
 
-  rdm_t* rdm = trexio_text_read_rdm((trexio_text_t*) file);
+  rdm_t* const rdm = trexio_text_read_rdm((trexio_text_t*) file);
   if (rdm == NULL) return TREXIO_FAILURE;
 
   if (dim_one_e != rdm->dim_one_e) return TREXIO_INVALID_ARG_3;
@@ -841,12 +849,16 @@ trexio_exit_code trexio_text_read_rdm_one_e(const trexio_t* file, double* one_e,
 }
 
  
-trexio_exit_code trexio_text_write_rdm_one_e(const trexio_t* file, const double* one_e, const uint64_t dim_one_e) {
+trexio_exit_code
+trexio_text_write_rdm_one_e(trexio_t* const file,
+                            const double* one_e,
+                            const uint64_t dim_one_e)
+{
   if (file  == NULL)  return TREXIO_INVALID_ARG_1;
   if (one_e == NULL)  return TREXIO_INVALID_ARG_2;
   if (file->mode != 'r') return TREXIO_READONLY;
 
-  rdm_t* rdm = trexio_text_read_rdm((trexio_text_t*) file);
+  rdm_t* const rdm = trexio_text_read_rdm((trexio_text_t*) file);
   if (rdm == NULL) return TREXIO_FAILURE;
   
   rdm->dim_one_e = dim_one_e;
@@ -868,18 +880,34 @@ trexio_exit_code trexio_text_write_rdm_one_e(const trexio_t* file, const double*
      file for each sparse float structure.
     
     #+begin_src c :tangle rdm_text.h
-trexio_exit_code trexio_text_buffered_read_rdm_two_e(const trexio_t* file, const uint64_t offset, const uint64_t size, int64_t* index, double* value);
-trexio_exit_code trexio_text_buffered_write_rdm_two_e(const trexio_t* file, const uint64_t offset, const uint64_t size, const int64_t* index, const double* value);
+trexio_exit_code
+trexio_text_buffered_read_rdm_two_e(trexio_t* const file,
+                                    const uint64_t offset,
+                                    const uint64_t size,
+                                    int64_t* const index,
+                                    double* const value);
+
+trexio_exit_code
+trexio_text_buffered_write_rdm_two_e(trexio_t* const file,
+                                     const uint64_t offset,
+                                     const uint64_t size,
+                                     const int64_t* index,
+                                     const double* value);
    #+end_src
 
     #+begin_src c :tangle rdm_text.c
-trexio_exit_code trexio_text_buffered_read_rdm_two_e(const trexio_t* file, const uint64_t offset, const uint64_t size, int64_t* index, double* value) {
-
+trexio_exit_code
+trexio_text_buffered_read_rdm_two_e(trexio_t* const file,
+                                    const uint64_t offset,
+                                    const uint64_t size,
+                                    int64_t* const index,
+                                    double* const value)
+{
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if (index == NULL) return TREXIO_INVALID_ARG_4;
   if (value == NULL) return TREXIO_INVALID_ARG_5;
 
-  rdm_t* rdm = trexio_text_read_rdm((trexio_text_t*) file);
+  rdm_t* const rdm = trexio_text_read_rdm((trexio_text_t*) file);
   if (rdm == NULL) return TREXIO_FAILURE;
 
   FILE* f = fopen(rdm->two_e_file_name, "r");
@@ -906,13 +934,19 @@ trexio_exit_code trexio_text_buffered_read_rdm_two_e(const trexio_t* file, const
 }
 
  
-trexio_exit_code trexio_text_buffered_write_rdm_two_e(const trexio_t* file, const uint64_t offset, const uint64_t size, const int64_t* index, const double* value) {
+trexio_exit_code
+trexio_text_buffered_write_rdm_two_e(trexio_t* const file,
+                                     const uint64_t offset,
+                                     const uint64_t size,
+                                     const int64_t* index,
+                                     const double* value)
+{
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if (index == NULL) return TREXIO_INVALID_ARG_4;
   if (value == NULL) return TREXIO_INVALID_ARG_5;
   if (file->mode != 'r') return TREXIO_READONLY;
 
-  rdm_t* rdm = trexio_text_read_rdm((trexio_text_t*) file);
+  rdm_t* const rdm = trexio_text_read_rdm((trexio_text_t*) file);
   if (rdm == NULL) return TREXIO_FAILURE;
 
   FILE* f = fopen(rdm->two_e_file_name, "w");

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -901,8 +901,6 @@ trexio_exit_code trexio_text_buffered_read_rdm_two_e(const trexio_t* file, const
       /* Do nothing */
     } else if (rc == EOF) {
       return TREXIO_END;
-    } else if (rc == EOF) {
-      return TREXIO_FAILURE;
     }
   }
 

--- a/src/test.c
+++ b/src/test.c
@@ -27,8 +27,6 @@ int test_h5write() {
   trexio_t* file = NULL;
   trexio_exit_code rc;
 
-  rc = TREXIO_SUCCESS;
-
   int64_t num = 12;
 
   double coord[36] = {


### PR DESCRIPTION
We are now compliant with CERT standard.
The only error remaining in our files is 
```
 style: Do not use fopen() better use fopen_s() [cert-MSC24-C]
```
But this is specific to C11. We prefer to stick to C99 because not all compilers have `fopen_s`.
