### PR TITLE
Add has_ functions everywhere + important bug fix in text backend

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -94,11 +94,11 @@ files_front = [f for f in listdir(templ_path_front) if isfile(join(templ_path_fr
 
 files = files_text + files_hdf5 + files_front
 
-files_funcs = [f for f in files if 'read_' in f or 'write_' in f or 'flush_' in f or 'free_' in f or 'rw_' in f ]
+files_funcs = [f for f in files if 'read_' in f or 'write_' in f or 'flush_' in f or 'free_' in f or 'hrw_' in f or 'has_' in f]
 files_funcs_dsets = [f for f in files_funcs if 'dset' in f]
 files_funcs_nums  = [f for f in files_funcs if 'num' in f]
 files_funcs_groups = [f for f in files_funcs if 'group' in f]
-files_auxil = [f for f in files if not ('read_' in f or 'write_' in f or 'rw_' in f)]
+files_auxil = [f for f in files if not ('read_' in f or 'write_' in f or 'hrw_' in f or 'has_' in f)]
 
 files_funcs_groups.append('struct_text_group_dset.h')
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -151,12 +151,14 @@ for fname in files_funcs_groups:
                                 templine2 = templine1.replace('$group$', grname)
 
                                 if params['dtype'] == 'double':
-                                    std_dtype = 'lf'
+                                    std_dtype_out = '24.16e'
+                                    std_dtype_in = 'lf'
                                 elif params['dtype'] == 'int64_t':
-                                    std_dtype = 'ld'
+                                    std_dtype_out = 'ld'
+                                    std_dtype_in = 'ld'
 
-                                templine1 = templine2.replace('$group_dset_std_dtype$', std_dtype)
-                                templine2 = templine1
+                                templine1 = templine2.replace('$group_dset_std_dtype_out$', std_dtype_out)
+                                templine2 = templine1.replace('$group_dset_std_dtype_in$', std_dtype_in)
 
                                 f_out.write(templine2)
                         elif do_num:

--- a/src/generator.py
+++ b/src/generator.py
@@ -16,10 +16,12 @@ print('Metadata I/O currently not supported')
 del config0['metadata']
 
 config = {}
-for k,v in config0.items():
-    if k == 'nucleus' or k == 'ecp':
-    #if k == 'nucleus':
-        config[k] = v
+#for k,v in config0.items():
+#    if k == 'nucleus' or k == 'ecp':
+#        config[k] = v
+config = config0
+# for now remove rdm because it is hardcoded
+del config['rdm']
 
 groups = [group for group in config.keys()]
 
@@ -111,7 +113,8 @@ for fname in files_funcs_groups:
     groups_done = []
     for group in config.keys():
 
-        grname = group.split('_')[0]
+        #grname = group.split('_')[0]
+        grname = group
         if grname in groups_done:
             continue
         else:
@@ -130,8 +133,8 @@ for fname in files_funcs_groups:
 
                         if do_dset:
                             for dset,params in datasets_nostr.items():
-                                dset_grname = dset.split('_')[0]
-                                if dset_grname != grname:
+                                #dset_grname = dset.split('_')[0]
+                                if grname not in dset: #dset_grname != grname:
                                     continue
 
                                 dset_allocated.append(dset)
@@ -165,8 +168,8 @@ for fname in files_funcs_groups:
                             #for dim in dim_variables.keys():
                             for dim in numbers.keys():
 
-                                num_grname = dim.split('_')[0]
-                                if num_grname != grname:
+                                #num_grname = dim.split('_')[0]
+                                if grname not in dim: #num_grname != grname:
                                     continue
 
                                 templine1 = loop_body.replace('$group_num$', dim)
@@ -195,8 +198,8 @@ for fname in files_funcs_groups:
                     if '$group_dset' in line and not subloop:
                         for dset,params in datasets_nostr.items():
 
-                            dset_grname = dset.split('_')[0]
-                            if dset_grname != grname:
+                            #dset_grname = dset.split('_')[0]
+                            if grname not in dset: #dset_grname != grname:
                                 continue
 
                             templine1 = line.replace('$group_dset$', dset)
@@ -212,8 +215,8 @@ for fname in files_funcs_groups:
                     elif '$group_num' in line and not subloop:
                         #for dim in dim_variables.keys():
                         for dim in numbers.keys():
-                            num_grname = dim.split('_')[0]
-                            if num_grname != grname:
+                            #num_grname = dim.split('_')[0]
+                            if grname not in dim: #num_grname != grname:
                                 continue
 
                             templine1 = line.replace('$GROUP_NUM$', dim.upper())
@@ -246,9 +249,15 @@ for fname in files_funcs_dsets:
 
     for dset,params in datasets_nostr.items():
 
-        grname = dset.split('_')[0]
+        #grname = dset.split('_')[0]
+        # the problem was when group name has underscores in it, special case needed!
+        for group_tmp in config.keys():
+            if group_tmp in dset:
+                grname = group_tmp
+
         with open(join(templ_path,fname), 'r') as f_in :
             with open(join(templ_path,fname_new), 'a') as f_out :
+                num_written = []
                 for line in f_in :
                     if '$' in line:
 
@@ -256,7 +265,8 @@ for fname in files_funcs_dsets:
                             rc_line = 'if (rc != TREXIO_SUCCESS) return rc;\n'
                             indentlevel = len(line) - len(line.lstrip())
                             for dim in params['dims']:
-                                if not dim.isdigit():
+                                if not dim.isdigit() and not dim in num_written:
+                                    num_written.append(dim)
                                     templine1 = line.replace('$group_dset_dim$', dim)
                                     templine2 = templine1
                                     if '_read' in templine2: # and 'hdf5' in fname:
@@ -264,6 +274,7 @@ for fname in files_funcs_dsets:
                                             templine2 += templine1
 
                                     f_out.write(templine2)
+                            num_written = []
                             continue
 
                         templine1 = line.replace('$GROUP$_$GROUP_DSET$', dset.upper())

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -12,7 +12,6 @@
   #+end_src
 
   #+begin_src fortran :tangle prefix_fortran.f90 :noweb yes
-
 module trexio
 
   use, intrinsic :: iso_c_binding
@@ -36,7 +35,8 @@ module trexio
   integer, parameter :: TREXIO_INVALID_ID        = 20
   integer, parameter :: TREXIO_ALLOCATION_FAILED = 21  
   integer, parameter :: TREXIO_INVALID_NUM       = 22  
-  
+  integer, parameter :: TREXIO_HAS_NOT           = 30
+
   #+end_src
 
   #+begin_src c :tangle prefix_front.h :noweb yes
@@ -128,6 +128,7 @@ typedef int32_t trexio_exit_code;
 #define TREXIO_INVALID_ID    ( (trexio_exit_code) 20 )
 #define TREXIO_ALLOCATION_FAILED  (  (trexio_exit_code)  21  )
 #define TREXIO_INVALID_NUM   ( (trexio_exit_code) 22 )
+#define TREXIO_HAS_NOT   ( (trexio_exit_code) 30 )
 
    #+end_src
    
@@ -401,15 +402,16 @@ end interface
    #+end_src
 
 * Templates for front end
-** Template for frontend read/write a number
+** Template for frontend has/read/write a number
    
-     #+begin_src c :tangle rw_num_front.h
+     #+begin_src c :tangle hrw_num_front.h
+trexio_exit_code trexio_has_$group_num$(trexio_t* const file);
 trexio_exit_code trexio_read_$group_num$(trexio_t* const file, int64_t* const num);
 trexio_exit_code trexio_write_$group_num$(trexio_t* const file, const int64_t num);
      #+end_src
    
      #+begin_src c :tangle read_num_front.c
-trexio_exit_code trexio_read_$group_num$(trexio_t* file, int64_t* num) {
+trexio_exit_code trexio_read_$group_num$(trexio_t* const file, int64_t* const num) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
 
   uint64_t u_num = 0;
@@ -433,13 +435,12 @@ trexio_exit_code trexio_read_$group_num$(trexio_t* file, int64_t* num) {
 
   if (rc != TREXIO_SUCCESS) return rc;
                               
-  /**/ *num = (int64_t) u_num;
+  *num = (int64_t) u_num;
   return TREXIO_SUCCESS;
 }
      #+end_src
    
      #+begin_src c :tangle write_num_front.c
-
 trexio_exit_code trexio_write_$group_num$(trexio_t* const file, const int64_t num) {
   if (file == NULL) return TREXIO_INVALID_ARG_1;
   if (num  <  0   ) return TREXIO_INVALID_ARG_2;
@@ -459,7 +460,7 @@ trexio_exit_code trexio_write_$group_num$(trexio_t* const file, const int64_t nu
   case TREXIO_JSON:
     rc = trexio_json_write_$group_num$(file, (uint64_t) num);
     break;
-,*/      
+,*/
   }
   if (rc != TREXIO_SUCCESS) return rc;
                               
@@ -467,9 +468,32 @@ trexio_exit_code trexio_write_$group_num$(trexio_t* const file, const int64_t nu
 }
      #+end_src
 
+     #+begin_src c :tangle has_num_front.c
+trexio_exit_code trexio_has_$group_num$(trexio_t* const file) {
+  if (file == NULL) return TREXIO_INVALID_ARG_1;
+
+  switch (file->back_end) {
+
+  case TREXIO_TEXT:
+    return trexio_text_has_$group_num$(file);
+    break;
+
+  case TREXIO_HDF5:
+    return trexio_hdf5_has_$group_num$(file);
+    break;
+/*
+  case TREXIO_JSON:
+    return trexio_json_has_$group_num$(file);
+    break;
+,*/
+  default:
+    return TREXIO_FAILURE;  /* Impossible case */
+  }
+
+}
+     #+end_src
 
      #+begin_src fortran :tangle write_num_front_fortran.f90
-
 interface
    integer function trexio_write_$group_num$ (trex_file, num) bind(C)
      use, intrinsic :: iso_c_binding
@@ -477,12 +501,9 @@ interface
      integer(8), intent(in), value :: num
    end function trexio_write_$group_num$
 end interface
-
      #+end_src
 
-
      #+begin_src fortran :tangle read_num_front_fortran.f90
-     
 interface
    integer function trexio_read_$group_num$ (trex_file, num) bind(C)
      use, intrinsic :: iso_c_binding
@@ -490,13 +511,21 @@ interface
      integer(8), intent(out) :: num
    end function trexio_read_$group_num$
 end interface
-
      #+end_src
 
+     #+begin_src fortran :tangle has_num_front_fortran.f90
+interface
+   integer function trexio_has_$group_num$ (trex_file) bind(C)
+     use, intrinsic :: iso_c_binding
+     integer(8), intent(in), value :: trex_file
+   end function trexio_has_$group_num$
+end interface
+     #+end_src
 
-** Template for frontend read/write a dataset
+** Template for frontend has/read/write a dataset
 
-     #+begin_src c :tangle rw_dset_front.h
+     #+begin_src c :tangle hrw_dset_front.h
+trexio_exit_code trexio_has_$group$_$group_dset$(trexio_t* const file);
 trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$);
 trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$);
      #+end_src
@@ -553,7 +582,6 @@ trexio_exit_code trexio_read_$group$_$group_dset$(trexio_t* const file, $group_d
      #+end_src
    
      #+begin_src c :tangle write_dset_front.c
-
 trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$) {
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if ($group_dset$ == NULL) return TREXIO_INVALID_ARG_2;
@@ -601,9 +629,33 @@ trexio_exit_code trexio_write_$group$_$group_dset$(trexio_t* const file, const $
   }
 }
      #+end_src
+
+     #+begin_src c :tangle has_dset_front.c
+trexio_exit_code trexio_has_$group$_$group_dset$(trexio_t* const file) {
+  if (file  == NULL) return TREXIO_INVALID_ARG_1;
+
+  switch (file->back_end) {
+
+  case TREXIO_TEXT:
+    return trexio_text_has_$group$_$group_dset$(file);
+    break;
+
+  case TREXIO_HDF5:
+    return trexio_hdf5_has_$group$_$group_dset$(file);
+    break;
+/*
+  case TREXIO_JSON:
+    return trexio_json_has_$group$_$group_dset$(file);
+    break;
+,*/
+  default:
+    return TREXIO_FAILURE;  /* Impossible case */
+  }
+}
+     #+end_src
+
    
      #+begin_src fortran :tangle write_dset_front_fortran.f90
-
 interface
    integer function trexio_write_$group$_$group_dset$ (trex_file, dset) bind(C)
      use, intrinsic :: iso_c_binding
@@ -611,11 +663,9 @@ interface
      $group_dset_f_dtype$, intent(in) :: dset(*)
    end function trexio_write_$group$_$group_dset$
 end interface
-
      #+end_src
 
      #+begin_src fortran :tangle read_dset_front_fortran.f90
-     
 interface
    integer function trexio_read_$group$_$group_dset$ (trex_file, dset) bind(C)
      use, intrinsic :: iso_c_binding
@@ -623,7 +673,15 @@ interface
      $group_dset_f_dtype$, intent(out) :: dset(*)
    end function trexio_read_$group$_$group_dset$
 end interface
+     #+end_src
 
+     #+begin_src fortran :tangle has_dset_front_fortran.f90
+interface
+   integer function trexio_has_$group$_$group_dset$ (trex_file) bind(C)
+     use, intrinsic :: iso_c_binding
+     integer(8), intent(in), value :: trex_file
+   end function trexio_has_$group$_$group_dset$
+end interface
      #+end_src
 
 * Back ends

--- a/src/templates_hdf5/build.sh
+++ b/src/templates_hdf5/build.sh
@@ -7,12 +7,14 @@ cat populated/pop_def_hdf5.c >> trexio_hdf5.c
 cat populated/pop_struct_hdf5.h >> trexio_hdf5.h
 
 cat populated/pop_basic_hdf5.c >> trexio_hdf5.c
+cat populated/pop_has_dset_hdf5.c >> trexio_hdf5.c
+cat populated/pop_has_num_hdf5.c >> trexio_hdf5.c
 cat populated/pop_read_dset_hdf5.c >> trexio_hdf5.c
 cat populated/pop_read_num_hdf5.c >> trexio_hdf5.c
 cat populated/pop_write_dset_hdf5.c >> trexio_hdf5.c
 cat populated/pop_write_num_hdf5.c >> trexio_hdf5.c
-cat populated/pop_rw_num_hdf5.h >> trexio_hdf5.h
-cat populated/pop_rw_dset_hdf5.h >> trexio_hdf5.h
+cat populated/pop_hrw_num_hdf5.h >> trexio_hdf5.h
+cat populated/pop_hrw_dset_hdf5.h >> trexio_hdf5.h
 
 cat suffix_hdf5.h   >> trexio_hdf5.h
 

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -123,7 +123,7 @@ trexio_exit_code trexio_hdf5_init(trexio_t* const file) {
       f->$group$_group = H5Gcreate(f->file_id, $GROUP$_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
       break;
   }
-  assert (f->$group$_group > 0L);
+  if (f->$group$_group <= 0L) return TREXIO_INVALID_ID;
 
   return TREXIO_SUCCESS;
 }

--- a/src/templates_hdf5/templator_hdf5.org
+++ b/src/templates_hdf5/templator_hdf5.org
@@ -118,15 +118,12 @@ trexio_exit_code trexio_hdf5_init(trexio_t* const file) {
     case 'r':
     case 'a': 
       f->$group$_group = H5Gopen(f->file_id, $GROUP$_GROUP_NAME, H5P_DEFAULT);
-      //f->electron_group = H5Gopen(f->file_id, ELECTRON_GROUP_NAME, H5P_DEFAULT); 
       break;
     case 'w':
       f->$group$_group = H5Gcreate(f->file_id, $GROUP$_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-      //f->electron_group = H5Gcreate(f->file_id, ELECTRON_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
       break;
   }
   assert (f->$group$_group > 0L);
-  //assert (f->electron_group > 0L);
 
   return TREXIO_SUCCESS;
 }
@@ -138,11 +135,6 @@ trexio_exit_code trexio_hdf5_finalize(trexio_t* const file) {
   H5Gclose(f->$group$_group);
   f->$group$_group = 0;
 
-/*
-  H5Gclose(f->electron_group);
-  f->electron_group = 0; 
-*/
-
   H5Fclose(f->file_id);
   f->file_id = 0;
 
@@ -152,10 +144,10 @@ trexio_exit_code trexio_hdf5_finalize(trexio_t* const file) {
   #+end_src
 
 
+** Template for HDF5 has/read/write a number
 
-** Template for HDF5 read/write a number
-
-  #+begin_src c :tangle rw_num_hdf5.h
+  #+begin_src c :tangle hrw_num_hdf5.h
+trexio_exit_code trexio_hdf5_has_$group_num$ (trexio_t* const file);
 trexio_exit_code trexio_hdf5_read_$group_num$ (trexio_t* const file, uint64_t* const num);
 trexio_exit_code trexio_hdf5_write_$group_num$(trexio_t* const file, const uint64_t num);
   #+end_src
@@ -163,9 +155,8 @@ trexio_exit_code trexio_hdf5_write_$group_num$(trexio_t* const file, const uint6
    
   #+begin_src c :tangle read_num_hdf5.c
 trexio_exit_code trexio_hdf5_read_$group_num$ (trexio_t* const file, uint64_t* const num) {
-
-  assert (file != NULL);
-  assert (num  != NULL);
+  if (file == NULL) return TREXIO_INVALID_ARG_1;
+  if (num  == NULL) return TREXIO_INVALID_ARG_2;
   
   const trexio_hdf5_t* f = (const trexio_hdf5_t*) file;
   /* Quit if the dimensioning attribute is missing in the file */
@@ -180,14 +171,13 @@ trexio_exit_code trexio_hdf5_read_$group_num$ (trexio_t* const file, uint64_t* c
 
   return TREXIO_SUCCESS;
 }
-    #+end_src
+   #+end_src
 
  
   #+begin_src c :tangle write_num_hdf5.c
 trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* const file, const uint64_t num) {
-
-  assert (file != NULL);
-  assert (num > 0L);
+  if (file == NULL) return TREXIO_INVALID_ARG_1;
+  if (num  == 0L  ) return TREXIO_INVALID_ARG_2;
  
   trexio_hdf5_t* const f = (trexio_hdf5_t*) file;
 
@@ -251,20 +241,36 @@ trexio_exit_code trexio_hdf5_write_$group_num$ (trexio_t* const file, const uint
 }
     #+end_src
 
+  #+begin_src c :tangle has_num_hdf5.c
+trexio_exit_code trexio_hdf5_has_$group_num$ (trexio_t* const file) {
+  if (file == NULL) return TREXIO_INVALID_ARG_1;
 
-** Template for HDF5 read/write a dataset
+  const trexio_hdf5_t* f = (const trexio_hdf5_t*) file;
 
+  htri_t status = H5Aexists(f->$group$_group, $GROUP_NUM$_NAME);
+  /* H5Aexists returns positive value if attribute exists, 0 if does not, negative if error */
+  if (status > 0){
+    return TREXIO_SUCCESS;
+  } else if (status == 0) {
+    return TREXIO_HAS_NOT;
+  } else {
+    return TREXIO_FAILURE;
+  }
+}
+    #+end_src
+
+** Template for HDF5 has/read/write a dataset
     
-   #+begin_src c :tangle rw_dset_hdf5.h
+   #+begin_src c :tangle hrw_dset_hdf5.h
+trexio_exit_code trexio_hdf5_has_$group$_$group_dset$(trexio_t* const file);
 trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims);
 trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
-  #+end_src
+   #+end_src
 
    #+begin_src c :tangle read_dset_hdf5.c
 trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims) {
-
-  assert (file != NULL);
-  assert ($group_dset$ != NULL);
+  if (file == NULL) return TREXIO_INVALID_ARG_1;
+  if ($group_dset$  == NULL) return TREXIO_INVALID_ARG_2;
   
   const trexio_hdf5_t* f = (const trexio_hdf5_t*) file;
   
@@ -312,13 +318,12 @@ trexio_exit_code trexio_hdf5_read_$group$_$group_dset$(trexio_t* const file, $gr
   return TREXIO_SUCCESS;
 }
 
-    #+end_src
+   #+end_src
 
    #+begin_src c :tangle write_dset_hdf5.c
 trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims) {
-
-  assert (file != NULL);
-  assert ($group_dset$ != NULL);
+  if (file == NULL) return TREXIO_INVALID_ARG_1;
+  if ($group_dset$  == NULL) return TREXIO_INVALID_ARG_2;
     
   trexio_exit_code rc;
   uint64_t $group_dset_dim$;
@@ -351,8 +356,25 @@ trexio_exit_code trexio_hdf5_write_$group$_$group_dset$(trexio_t* const file, co
   
   return TREXIO_SUCCESS;
 }
-  #+end_src
+   #+end_src
 
+   #+begin_src c :tangle has_dset_hdf5.c
+trexio_exit_code trexio_hdf5_has_$group$_$group_dset$(trexio_t* const file) {
+  if (file == NULL) return TREXIO_INVALID_ARG_1;
+
+  trexio_hdf5_t* f = (trexio_hdf5_t*) file;
+
+  herr_t status = H5LTfind_dataset(f->$group$_group, $GROUP$_$GROUP_DSET$_NAME);
+  /* H5LTfind_dataset returns 1 if dataset exists, 0 otherwise */
+  if (status == 1){
+    return TREXIO_SUCCESS;
+  } else if (status == 0) {
+    return TREXIO_HAS_NOT;
+  } else {
+    return TREXIO_FAILURE;
+  }
+}
+   #+end_src
 
 ** Constant file suffixes (not used by generator) for HDF5          :noxport:  
 

--- a/src/templates_text/build.sh
+++ b/src/templates_text/build.sh
@@ -17,12 +17,14 @@ cat populated/pop_free_group_text.h >> trexio_text.h
 cat populated/pop_read_group_text.h >> trexio_text.h
 cat populated/pop_flush_group_text.h >> trexio_text.h
 
+cat populated/pop_has_dset_text.c >> trexio_text.c
+cat populated/pop_has_num_text.c >> trexio_text.c
 cat populated/pop_read_dset_text.c >> trexio_text.c
 cat populated/pop_read_num_text.c >> trexio_text.c
 cat populated/pop_write_dset_text.c >> trexio_text.c
 cat populated/pop_write_num_text.c >> trexio_text.c
-cat populated/pop_rw_num_text.h >> trexio_text.h
-cat populated/pop_rw_dset_text.h >> trexio_text.h
+cat populated/pop_hrw_num_text.h >> trexio_text.h
+cat populated/pop_hrw_dset_text.h >> trexio_text.h
 
 cat rdm_text.c >> trexio_text.c
 cat rdm_text.h >> trexio_text.h

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -441,7 +441,7 @@ trexio_exit_code trexio_text_flush_$group$(trexio_text_t* const file) {
   if ($group$->to_flush == 0) return TREXIO_SUCCESS;
 
   FILE* f = $group$->file;
-  assert (f != NULL);
+  if (f == NULL) return TREXIO_INVALID_ARG_1;
   fseek(f, 0L, SEEK_SET);
 
   /* Write the dimensioning variables */

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -513,16 +513,16 @@ trexio_exit_code trexio_text_free_$group$(trexio_text_t* const file) {
 }
     #+end_src
 
-** Template for read/write the $group_num$ attribute
+** Template for has/read/write the $group_num$ attribute
 
-    #+begin_src c :tangle rw_num_text.h
+    #+begin_src c :tangle hrw_num_text.h
+trexio_exit_code trexio_text_has_$group_num$ (trexio_t* const file);
 trexio_exit_code trexio_text_read_$group_num$ (trexio_t* const file, uint64_t* const num);
 trexio_exit_code trexio_text_write_$group_num$(trexio_t* const file, const uint64_t num);
    #+end_src
 
     #+begin_src c :tangle read_num_text.c
 trexio_exit_code trexio_text_read_$group_num$(trexio_t* const file, uint64_t* const num) {
-
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
   if (num   == NULL) return TREXIO_INVALID_ARG_2;
 
@@ -538,9 +538,7 @@ trexio_exit_code trexio_text_read_$group_num$(trexio_t* const file, uint64_t* co
    #+begin_src c :tangle write_num_text.c
  
 trexio_exit_code trexio_text_write_$group_num$(trexio_t* const file, const uint64_t num) {
-
   if (file == NULL) return TREXIO_INVALID_ARG_1;
-
   if (file->mode == 'r') return TREXIO_READONLY;
   
   $group$_t* $group$ = trexio_text_read_$group$((trexio_text_t*) file);
@@ -553,16 +551,34 @@ trexio_exit_code trexio_text_write_$group_num$(trexio_t* const file, const uint6
 }
      #+end_src
 
-** Template for read/write the $group_dset$ dataset
+    #+begin_src c :tangle has_num_text.c
+trexio_exit_code trexio_text_has_$group_num$(trexio_t* const file) {
+  if (file  == NULL) return TREXIO_INVALID_ARG_1;
+
+  $group$_t* $group$ = trexio_text_read_$group$((trexio_text_t*) file);
+  if ($group$ == NULL) return TREXIO_FAILURE;
+
+  if ($group$->$group_num$ > 0L){
+    return TREXIO_SUCCESS;
+  } else {
+    return TREXIO_HAS_NOT;
+  }
+
+}
+   #+end_src
+
+
+** Template for has/read/write the $group_dset$ dataset
 
      The ~dset~ array is assumed allocated with the appropriate size.
     
-    #+begin_src c :tangle rw_dset_text.h
+   #+begin_src c :tangle hrw_dset_text.h
+trexio_exit_code trexio_text_has_$group_dset$ (trexio_t* const file);
 trexio_exit_code trexio_text_read_$group_dset$ (trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims);
 trexio_exit_code trexio_text_write_$group_dset$(trexio_t* const file, const $group_dset_dtype$* $group_dset$, const uint32_t rank, const uint64_t* dims);
    #+end_src
 
-    #+begin_src c :tangle read_dset_text.c
+   #+begin_src c :tangle read_dset_text.c
 trexio_exit_code trexio_text_read_$group_dset$(trexio_t* const file, $group_dset_dtype$* const $group_dset$, const uint32_t rank, const uint64_t* dims) {
 
   if (file  == NULL) return TREXIO_INVALID_ARG_1;
@@ -618,8 +634,22 @@ trexio_exit_code trexio_text_write_$group_dset$(trexio_t* const file, const $gro
   $group$->to_flush = 1;
   return TREXIO_SUCCESS;
 }
-     #+end_src
-     
+   #+end_src
+
+   #+begin_src c :tangle has_dset_text.c
+trexio_exit_code trexio_text_has_$group_dset$(trexio_t* const file) {
+  if (file  == NULL) return TREXIO_INVALID_ARG_1;
+
+  $group$_t* const $group$ = trexio_text_read_$group$((trexio_text_t*) file);
+  if ($group$ == NULL) return TREXIO_FAILURE;
+
+  if ($group$->rank_$group_dset$ > 0){
+    return TREXIO_SUCCESS;
+  } else {
+    return TREXIO_HAS_NOT;
+  }
+}
+   #+end_src
 
 ** RDM struct
 *** Read the complete struct

--- a/src/templates_text/templator_text.org
+++ b/src/templates_text/templator_text.org
@@ -385,7 +385,7 @@ $group$_t* trexio_text_read_$group$(trexio_text_t* const file) {
     }
     
     for (uint64_t i=0 ; i<size_$group_dset$ ; ++i) {
-      rc = fscanf(f, "%$group_dset_std_dtype$", &($group$->$group_dset$[i]));
+      rc = fscanf(f, "%$group_dset_std_dtype_in$", &($group$->$group_dset$[i]));
       assert(!(rc != 1));
       if (rc != 1) {
         FREE(buffer);
@@ -467,7 +467,7 @@ trexio_exit_code trexio_text_flush_$group$(trexio_text_t* const file) {
 
   fprintf(f, "$group_dset$\n");
   for (uint64_t i=0 ; i<size_$group_dset$ ; ++i) {
-    fprintf(f, "%$group_dset_std_dtype$\n", $group$->$group_dset$[i]);
+    fprintf(f, "%$group_dset_std_dtype_out$\n", $group$->$group_dset$[i]);
   }
   // END REPEAT GROUP_DSET
 

--- a/src/test.c
+++ b/src/test.c
@@ -6,27 +6,31 @@
 
 int test_read();
 int test_write();
-
 int test_h5read();
 int test_h5write();
 
 int main() {
+
+/*============== Main test launcher ================*/
 
   test_h5write();
   test_h5read();
 
   test_write();
   test_read();
+
   return 0 ;
 }
 
-
 int test_h5write() {
-  const char* file_name = "test_write.h5";
 
+/*======== Test write using HDF5 backend ===========*/
+
+  const char* file_name = "test_write.h5";
   trexio_t* file = NULL;
   trexio_exit_code rc;
 
+  // parameters to be written
   int64_t num = 12;
 
   double coord[36] = {
@@ -44,26 +48,31 @@ int test_h5write() {
   0.00000000 ,  2.47304151 ,  0.00000000 ,
   };
 
+/*================= START OF TEST ==================*/
+
+  // open file in 'write' mode
   file = trexio_open(file_name, 'w', TREXIO_HDF5);
   assert (file != NULL);
 
+  // check that certain data does not exist in the file
   rc = trexio_has_nucleus_num(file);
   assert (rc == TREXIO_HAS_NOT);
   rc = trexio_has_nucleus_coord(file);
   assert (rc == TREXIO_HAS_NOT);
 
-  // works: try writing info in an empty file
+  // write info in an empty file
   rc = trexio_write_nucleus_num(file,num);
   assert (rc == TREXIO_SUCCESS);
   rc = trexio_write_nucleus_coord(file,coord);
   assert (rc == TREXIO_SUCCESS);
 
+  // check if the written data exists in the file
   rc = trexio_has_nucleus_num(file);
   assert (rc == TREXIO_SUCCESS);
   rc = trexio_has_nucleus_coord(file);
   assert (rc == TREXIO_SUCCESS);
 
-  // should not work: try to rewrite the nucleus_num
+  // should not work: try to overwrite the nucleus_num
   rc = trexio_write_nucleus_num(file,25);
   assert (rc != TREXIO_SUCCESS);
 
@@ -71,82 +80,94 @@ int test_h5write() {
   rc = trexio_close(file);
   assert (rc == TREXIO_SUCCESS);
 
+  // open file again in 'append' mode
   file = trexio_open(file_name, 'a', TREXIO_HDF5);
   assert (file != NULL);
   
-  // works: try to read the nucleus_num from existing file
+  // read the nucleus_num from existing file
   rc = trexio_read_nucleus_num(file,&num);
   assert (rc == TREXIO_SUCCESS);
   assert (num == 12);
 
-  // works: try to rewrite the nucleus_coord
+  // overwrite the nucleus_coord
   coord[0] = 666.666;
   rc = trexio_write_nucleus_coord(file,coord);
   assert (rc == TREXIO_SUCCESS);
 
+  // close current session
   rc = trexio_close(file);
   assert (rc == TREXIO_SUCCESS);
+
+/*================= END OF TEST ==================*/
 
   return 0;
 }
 
 int test_h5read() {
-  const char* file_name = "test_write.h5";
 
+/*========= Test read using HDF5 backend ===========*/
+
+  const char* file_name = "test_write.h5";
   trexio_t* file = NULL;
   trexio_exit_code rc;
 
   int64_t num;
   double* coord;
 
-  // test reading existing file [created by test_h5write()], should work
+/*================= START OF TEST ==================*/
+
+  // open existing file on 'read' mode [created by test_h5write()]
   file = trexio_open(file_name, 'r', TREXIO_HDF5);
   assert (file != NULL);
 
+  // read nucleus_num
   rc = trexio_read_nucleus_num(file,&num);
   assert (rc == TREXIO_SUCCESS);
   assert (num == 12);
 
+  // read nucleus_coord
   coord = (double*) calloc(3*num, sizeof(double));
   rc = trexio_read_nucleus_coord(file,coord);
   assert (rc == TREXIO_SUCCESS);
 
   double x = coord[30] - 2.14171677;
-  assert( x*x < 1.e-12);
+  assert( x*x < 1.e-14);
 
+  // close current session
   rc = trexio_close(file);
   assert (rc == TREXIO_SUCCESS);
 
-  // test reading non-existing file, should fail and return NULL
+  // read non-existing file, should fail and return NULL
   const char* file_name2 = "test_nonexisting.h5";
   trexio_t* file2 = NULL;
 
   file2 = trexio_open(file_name2, 'r', TREXIO_HDF5);
   assert (file2 == NULL);
 
-  // test appending non-existing file, should fail and return NULL
+  // append non-existing file, should fail and return NULL
   trexio_t* file3 = NULL;
 
   file3 = trexio_open(file_name2, 'a', TREXIO_HDF5);
   assert (file3 == NULL);
 
-  free(coord);
+/*================= END OF TEST =====================*/
 
+  free(coord);
   return 0;
 }
 
 
 int test_write() {
-  const char* file_name = "trexio_test";
 
+/*========= Test write using TEXT backend ===========*/
+
+  const char* file_name = "trexio_test";
   trexio_t* file = NULL;
   trexio_exit_code rc;
 
-
+  // parameters to be written
   int64_t num = 12;
-
   double charge[12] = {6., 6., 6., 6., 6., 6., 1., 1., 1., 1., 1., 1.};
-
   double coord[36] = {
   0.00000000 ,  1.39250319 ,  0.00000000 ,
  -1.20594314 ,  0.69625160 ,  0.00000000 ,
@@ -161,6 +182,8 @@ int test_write() {
   2.14171677 ,  1.23652075 ,  0.00000000 ,
   0.00000000 ,  2.47304151 ,  0.00000000 ,
   };
+
+/*================= START OF TEST ==================*/
 
   file = trexio_open(file_name, 'w', TREXIO_TEXT);
   assert (file != NULL);
@@ -187,18 +210,24 @@ int test_write() {
   rc = trexio_close(file);
   assert (rc == TREXIO_SUCCESS);
 
+/*================= END OF TEST =====================*/
+
   return 0;
 }
 
 int test_read() {
-  const char* file_name = "trexio_test";
 
+/*========= Test read using TEXT backend ===========*/
+	
+  const char* file_name = "trexio_test";
   trexio_t* file = NULL;
   trexio_exit_code rc;
 
   int64_t num;
   double* charge;
   double* coord;
+
+/*================= START OF TEST ==================*/
 
   file = trexio_open(file_name, 'r', TREXIO_TEXT);
   assert (file != NULL);
@@ -217,14 +246,15 @@ int test_read() {
   assert (rc == TREXIO_SUCCESS);
 
   double x = coord[30] - 2.14171677;
-  assert( x*x < 1.e-12);
+  assert(x*x < 1.e-14);
 
   rc = trexio_close(file);
   assert (rc == TREXIO_SUCCESS);
 
+/*================= END OF TEST =====================*/
+
   free(charge);
   free(coord);
-
   return 0;
 }
 

--- a/src/test.c
+++ b/src/test.c
@@ -47,10 +47,20 @@ int test_h5write() {
   file = trexio_open(file_name, 'w', TREXIO_HDF5);
   assert (file != NULL);
 
+  rc = trexio_has_nucleus_num(file);
+  assert (rc == TREXIO_HAS_NOT);
+  rc = trexio_has_nucleus_coord(file);
+  assert (rc == TREXIO_HAS_NOT);
+
   // works: try writing info in an empty file
   rc = trexio_write_nucleus_num(file,num);
   assert (rc == TREXIO_SUCCESS);
   rc = trexio_write_nucleus_coord(file,coord);
+  assert (rc == TREXIO_SUCCESS);
+
+  rc = trexio_has_nucleus_num(file);
+  assert (rc == TREXIO_SUCCESS);
+  rc = trexio_has_nucleus_coord(file);
   assert (rc == TREXIO_SUCCESS);
 
   // should not work: try to rewrite the nucleus_num
@@ -100,10 +110,6 @@ int test_h5read() {
   coord = (double*) calloc(3*num, sizeof(double));
   rc = trexio_read_nucleus_coord(file,coord);
   assert (rc == TREXIO_SUCCESS);
-
-  /*for (size_t i=0; i<3*num; i++){
-	  printf("%lf \n", coord[i]);
-  }*/
 
   double x = coord[30] - 2.14171677;
   assert( x*x < 1.e-12);
@@ -159,6 +165,11 @@ int test_write() {
   file = trexio_open(file_name, 'w', TREXIO_TEXT);
   assert (file != NULL);
 
+  rc = trexio_has_nucleus_num(file);
+  assert (rc == TREXIO_HAS_NOT);
+  rc = trexio_has_nucleus_coord(file);
+  assert (rc == TREXIO_HAS_NOT);
+
   rc = trexio_write_nucleus_num(file,num);
   assert (rc == TREXIO_SUCCESS);
 
@@ -166,6 +177,11 @@ int test_write() {
   assert (rc == TREXIO_SUCCESS);
 
   rc = trexio_write_nucleus_coord(file,coord);
+  assert (rc == TREXIO_SUCCESS);
+
+  rc = trexio_has_nucleus_num(file);
+  assert (rc == TREXIO_SUCCESS);
+  rc = trexio_has_nucleus_coord(file);
   assert (rc == TREXIO_SUCCESS);
 
   rc = trexio_close(file);

--- a/src/test.f90
+++ b/src/test.f90
@@ -33,17 +33,27 @@ subroutine test_write()
              2.14171677 ,  1.23652075 ,  0.00000000 , &
              0.00000000 ,  2.47304151 ,  0.00000000 /)
 
-!  trex_file = trexio_open('trexio_test_fort', 'w', TREXIO_TEXT)
-   trex_file = trexio_open('test_hdf5_fort.h5', 'w', TREXIO_HDF5)
+  trex_file = trexio_open('trexio_test_fort', 'w', TREXIO_TEXT)
+!  trex_file = trexio_open('test_hdf5_fort.h5', 'w', TREXIO_HDF5)
+
+  rc = trexio_has_nucleus_num(trex_file)
+  if (rc == TREXIO_HAS_NOT) write(*,*) 'SUCCESS HAS NOT 1' 
+  rc = trexio_has_nucleus_charge(trex_file)
+  if (rc == TREXIO_HAS_NOT) write(*,*) 'SUCCESS HAS NOT 2' 
 
   rc = trexio_write_nucleus_num(trex_file, num)
   if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS WRITE NUM'
-
+  
   rc = trexio_write_nucleus_charge(trex_file, charge)
   if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS WRITE CHARGE'
 
   rc = trexio_write_nucleus_coord(trex_file, coord)
   if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS WRITE COORD'
+
+  rc = trexio_has_nucleus_num(trex_file)
+  if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS HAS 1' 
+  rc = trexio_has_nucleus_coord(trex_file)
+  if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS HAS 2' 
 
   rc = trexio_close(trex_file)
   if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS CLOSE' 
@@ -82,8 +92,8 @@ subroutine test_read()
 
   num = 12
 
-!  trex_file = trexio_open('trexio_test_fort', 'r', TREXIO_TEXT)
-  trex_file = trexio_open('test_hdf5_fort.h5', 'r', TREXIO_HDF5)
+  trex_file = trexio_open('trexio_test_fort', 'r', TREXIO_TEXT)
+!  trex_file = trexio_open('test_hdf5_fort.h5', 'r', TREXIO_HDF5)
 
   rc = trexio_read_nucleus_num(trex_file, num_read)
 

--- a/src/test.f90
+++ b/src/test.f90
@@ -6,6 +6,8 @@ program test_trexio
 end program test_trexio
 
 subroutine test_write()
+
+! ============ Test write functionality =============== !
    
   use trexio
   implicit none
@@ -18,20 +20,23 @@ subroutine test_write()
   double precision :: charge(12)
   double precision :: coord(36)
 
+  ! parameters to be written
   num = 12
   charge = (/6., 6., 6., 6., 6., 6., 1., 1., 1., 1., 1., 1. /)
-  coord = (/ 0.00000000 ,  1.39250319 ,  0.00000000 , &
-            -1.20594314 ,  0.69625160 ,  0.00000000 , &
-            -1.20594314 , -0.69625160 ,  0.00000000 , &
-             0.00000000 , -1.39250319 ,  0.00000000 , &
-             1.20594314 , -0.69625160 ,  0.00000000 , &
-             1.20594314 ,  0.69625160 ,  0.00000000 , &
-            -2.14171677 ,  1.23652075 ,  0.00000000 , &
-            -2.14171677 , -1.23652075 ,  0.00000000 , &
-             0.00000000 , -2.47304151 ,  0.00000000 , &
-             2.14171677 , -1.23652075 ,  0.00000000 , &
-             2.14171677 ,  1.23652075 ,  0.00000000 , &
-             0.00000000 ,  2.47304151 ,  0.00000000 /)
+  coord = (/ 0.00000000d0,  1.39250319d0 ,  0.00000000d0 , &
+            -1.20594314d0,  0.69625160d0 ,  0.00000000d0 , &
+            -1.20594314d0, -0.69625160d0 ,  0.00000000d0 , &
+             0.00000000d0, -1.39250319d0 ,  0.00000000d0 , &
+             1.20594314d0, -0.69625160d0 ,  0.00000000d0 , &
+             1.20594314d0,  0.69625160d0 ,  0.00000000d0 , &
+            -2.14171677d0,  1.23652075d0 ,  0.00000000d0 , &
+            -2.14171677d0, -1.23652075d0 ,  0.00000000d0 , &
+             0.00000000d0, -2.47304151d0 ,  0.00000000d0 , &
+             2.14171677d0, -1.23652075d0 ,  0.00000000d0 , &
+             2.14171677d0,  1.23652075d0 ,  0.00000000d0 , &
+             0.00000000d0,  2.47304151d0 ,  0.00000000d0 /)
+
+! ================= START OF TEST ===================== !
 
   trex_file = trexio_open('trexio_test_fort', 'w', TREXIO_TEXT)
 !  trex_file = trexio_open('test_hdf5_fort.h5', 'w', TREXIO_HDF5)
@@ -75,9 +80,13 @@ subroutine test_write()
 !  rc = trexio_close(trex_file)
 !  if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS CLOSE' 
 
+! ================= END OF TEST ===================== !
+
 end subroutine test_write
 
 subroutine test_read()
+
+! ============ Test read functionality =============== !
 
   use trexio
   implicit none
@@ -92,6 +101,8 @@ subroutine test_read()
 
   num = 12
 
+! ================= START OF TEST ===================== !
+
   trex_file = trexio_open('trexio_test_fort', 'r', TREXIO_TEXT)
 !  trex_file = trexio_open('test_hdf5_fort.h5', 'r', TREXIO_HDF5)
 
@@ -101,14 +112,16 @@ subroutine test_read()
 
   rc = trexio_read_nucleus_charge(trex_file, charge)
    
-  if (rc == TREXIO_SUCCESS .and. (abs (charge(11) - 1.0) < 1.0D-8) ) write(*,*) 'SUCCESS READ CHARGE'
+  if (rc == TREXIO_SUCCESS .and. (abs(charge(11) - 1.0) < 1.0D-8) ) write(*,*) 'SUCCESS READ CHARGE'
 
   rc = trexio_read_nucleus_coord(trex_file, coord)
-   
-  if (rc == TREXIO_SUCCESS .and. (abs (coord(2,1) - 1.39250319) < 1.0D-8) ) write(*,*) 'SUCCESS READ COORD'
+
+  if (rc == TREXIO_SUCCESS .and. (abs(coord(2,1) - 1.39250319d0) < 1.0D-8) ) write(*,*) 'SUCCESS READ COORD'
 
   rc = trexio_close(trex_file)
   if (rc == TREXIO_SUCCESS) write(*,*) 'SUCCESS CLOSE' 
+
+! ================= END OF TEST ===================== !
 
 end subroutine test_read
 


### PR DESCRIPTION
1. `trexio_has_` functions introduced to check if a dimensioning variable or a dataset exists in the file
2. bug in text was due to the use of `%lf` option for `fprintf`:
  - Problem: C outputs 6 decimal points for floating point numbers by default
  - Solution: Specified the output format `%24.16e `