### PR TITLE
Automatically add package version to the metadata; Close #53

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,11 @@ AC_SUBST([VERSION_MAJOR])
 AC_SUBST([VERSION_MINOR])
 AC_SUBST([VERSION_PATCH])
 
+## Save system information, e.g. user name
+
+UNAME=`echo ${USER}`
+AC_DEFINE_UNQUOTED(TREXIO_USER_NAME, ["${UNAME}"], [user name])
+AC_SUBST([UNAME])
 
 ## -------------------
 ## Checks for programs 
@@ -49,6 +54,7 @@ PKG_CFLAGS=""
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_PROG_LN_S
+AC_PROG_GREP
 
 
 ## ---------

--- a/src/templates_front/build.sh
+++ b/src/templates_front/build.sh
@@ -6,7 +6,6 @@ cat prefix_front.h   > trexio.h
 # grep some usefull constants from the config.h
 echo "" >> trexio.h
 grep "_VERSION" ../../include/config.h >> trexio.h
-grep "_USER_NAME" ../../include/config.h >> trexio.h
 echo "" >> trexio.h
 
 cat prefix_s_front.h > trexio_s.h

--- a/src/templates_front/build.sh
+++ b/src/templates_front/build.sh
@@ -3,6 +3,12 @@
 # prefixes
 cat prefix_front.c   > trexio.c
 cat prefix_front.h   > trexio.h
+# grep some usefull constants from the config.h
+echo "" >> trexio.h
+grep "_VERSION" ../../include/config.h >> trexio.h
+grep "_USER_NAME" ../../include/config.h >> trexio.h
+echo "" >> trexio.h
+
 cat prefix_s_front.h > trexio_s.h
 cat prefix_fortran.f90   > trexio_f.f90
 

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -432,6 +432,7 @@ typedef struct trexio_s trexio_t;
    #+begin_src c :tangle prefix_s_front.h
 struct trexio_s {
   char              file_name[TREXIO_MAX_FILENAME_LENGTH];
+  char              version[16];
   pthread_mutex_t   thread_lock;
   back_end_t        back_end;
   char              mode;
@@ -528,6 +529,12 @@ trexio_open(const char* file_name, const char mode,
     return NULL;
   }
 
+  strncpy(result->version, PACKAGE_VERSION, 16);
+  if (result->version[15] != '\0') {
+    free(result);
+    return NULL;
+  }
+
   result->back_end    = back_end;
   result->mode        = mode;
   result->one_based   = false;  // Need to be flipped in Fortran interface
@@ -560,6 +567,36 @@ trexio_open(const char* file_name, const char mode,
     free(result);
     return NULL;
   }
+
+  rc = trexio_has_metadata_package_version(result);
+  if (rc == TREXIO_FAILURE) {
+    free(result);
+    return NULL;
+  }
+ 
+  if (rc == TREXIO_HAS_NOT) {
+    switch (back_end) {
+
+    case TREXIO_TEXT:
+      rc = trexio_text_write_metadata_package_version(result, PACKAGE_VERSION);
+      break;
+
+    case TREXIO_HDF5:
+      rc = trexio_hdf5_write_metadata_package_version(result, PACKAGE_VERSION);
+      break;
+/*
+    case TREXIO_JSON:
+      rc = trexio_json_write_metadata_package_version(result, PACKAGE_VERSION);
+      break;
+,*/
+    }
+  }
+
+  if (rc != TREXIO_SUCCESS) {
+    free(result);
+    return NULL;
+  }
+
 
   /* File locking */
 

--- a/trex.org
+++ b/trex.org
@@ -33,27 +33,29 @@ arrays are 0-based. Hence, we introduce the ~index~ type which is an
   authors of the file, and a textual description.
 
   #+NAME: metadata
-  | Variable      | Type  | Dimensions (for arrays) | Description                              |
-  |---------------+-------+-------------------------+------------------------------------------|
-  | ~code_num~    | ~int~ |                         | Number of codes used to produce the file |
-  | ~code~        | ~str~ | ~(metadata.code_num)~   | Names of the codes used                  |
-  | ~author_num~  | ~int~ |                         | Number of authors of the file            |
-  | ~author~      | ~str~ | ~(metadata.author_num)~ | Names of the authors of the file         |
-  | ~description~ | ~str~ |                         | Text describing the content of file      |
+  | Variable          | Type  | Dimensions (for arrays) | Description                              |
+  |-------------------+-------+-------------------------+------------------------------------------|
+  | ~code_num~        | ~int~ |                         | Number of codes used to produce the file |
+  | ~code~            | ~str~ | ~(metadata.code_num)~   | Names of the codes used                  |
+  | ~author_num~      | ~int~ |                         | Number of authors of the file            |
+  | ~author~          | ~str~ | ~(metadata.author_num)~ | Names of the authors of the file         |
+  | ~package_version~ | ~str~ |                         | TREXIO version used to produce the file  |
+  | ~description~     | ~str~ |                         | Text describing the content of file      |
 
   #+CALL: json(data=metadata, title="metadata")
   #+RESULTS:
-  :results:
+  :RESULTS:
   #+begin_src python :tangle trex.json
       "metadata": {
-             "code_num" : [ "int", []                        ]
-        ,        "code" : [ "str", [ "metadata.code_num" ]   ]
-        ,  "author_num" : [ "int", []                        ]
-        ,      "author" : [ "str", [ "metadata.author_num" ] ]
-        , "description" : [ "str", []                        ]
+		 "code_num" : [ "int", []                        ]
+	,            "code" : [ "str", [ "metadata.code_num" ]   ]
+	,      "author_num" : [ "int", []                        ]
+	,          "author" : [ "str", [ "metadata.author_num" ] ]
+	, "package_version" : [ "str", []                        ]
+	,     "description" : [ "str", []                        ]
       } ,
   #+end_src
-  :end:
+  :END:
 
 * Electron (electron group)
 


### PR DESCRIPTION
This PR fixes #53 by automatically writing TREXIO version to the corresponding attribute of the `metadata` group upon creation of the TREXIO file.

Additionally, user name is now propagated all the way from the environment variable `$USER` to the corresponding constant definition in the `trexio.h` file. This is useful for re-solving #54, even though I am not convinced that we need it at the current stage.