### PR TITLE
Compilation without HDF5

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,10 +36,6 @@ ACLOCAL_AMFLAGS = -I m4
 CLEANFILES = trexio.mod
 BUILT_SOURCES = trexio.mod
 
-VERSION_MAJOR   = @VERSION_MAJOR@
-VERSION_MINOR   = @VERSION_MINOR@
-VERSION_PATCH   = @VERSION_PATCH@
-
 SUBDIRS = 
 
 pkgconfigdir = $(libdir)/pkgconfig
@@ -62,10 +58,15 @@ SOURCES = \
   src/trexio.c \
   src/trexio_private.h \
   src/trexio_s.h \
-  src/trexio_hdf5.c \
-  src/trexio_hdf5.h \
   src/trexio_text.c \
   src/trexio_text.h
+
+if DO_HDF5 
+
+SOURCES += src/trexio_hdf5.c \
+           src/trexio_hdf5.h 
+
+endif
 
 ORG_FILES = \
   src/templates_front/templator_front.org \
@@ -79,23 +80,29 @@ src_libtrexio_la_SOURCES = $(SOURCES)
 # =============== TESTS =============== #
 
 TESTS_C = \
-  tests/open_hdf5 \
   tests/open_text \
-  tests/io_num_hdf5 \
   tests/io_num_text \
-  tests/io_dset_float_hdf5 \
   tests/io_dset_float_text \
-  tests/io_dset_int_hdf5 \
   tests/io_dset_int_text \
-  tests/io_safe_dset_float_hdf5 \
   tests/io_safe_dset_float_text \
-  tests/io_str_hdf5 \
   tests/io_str_text \
-  tests/io_dset_str_hdf5 \
   tests/io_dset_str_text \
-  tests/overwrite_all_hdf5 \
   tests/overwrite_all_text \
   tests/io_all
+
+if DO_HDF5 
+
+TESTS_C += \
+  tests/open_hdf5 \
+  tests/io_num_hdf5 \
+  tests/io_dset_float_hdf5 \
+  tests/io_dset_int_hdf5 \
+  tests/io_safe_dset_float_hdf5 \
+  tests/io_str_hdf5 \
+  tests/io_dset_str_hdf5 \
+  tests/overwrite_all_hdf5 
+
+endif
 
 TESTS_F = \
   tests/test_f
@@ -108,23 +115,29 @@ LDADD = src/libtrexio.la
 
 # in principal, specifying -no-install (see below) is not mandatory
 # for the tests to compile and pass, but the produced test binaries differ 
-tests_open_hdf5_LDFLAGS = -no-install
 tests_open_text_LDFLAGS = -no-install
-tests_io_num_hdf5_LDFLAGS = -no-install
 tests_io_num_text_LDFLAGS = -no-install
-tests_io_dset_float_hdf5_LDFLAGS = -no-install
 tests_io_dset_float_text_LDFLAGS = -no-install
-tests_io_dset_int_hdf5_LDFLAGS = -no-install
 tests_io_dset_int_text_LDFLAGS = -no-install
-tests_io_safe_dset_float_hdf5_LDFLAGS = -no-install
 tests_io_safe_dset_float_text_LDFLAGS = -no-install
-tests_io_str_hdf5_LDFLAGS = -no-install
 tests_io_str_text_LDFLAGS = -no-install
-tests_io_dset_str_hdf5_LDFLAGS = -no-install
 tests_io_dset_str_text_LDFLAGS = -no-install
-tests_overwrite_all_hdf5_LDFLAGS = -no-install
 tests_overwrite_all_text_LDFLAGS = -no-install
 tests_io_all_LDFLAGS = -no-install
+
+if DO_HDF5 
+
+tests_open_hdf5_LDFLAGS = -no-install
+tests_io_num_hdf5_LDFLAGS = -no-install
+tests_io_dset_float_hdf5_LDFLAGS = -no-install
+tests_io_dset_int_hdf5_LDFLAGS = -no-install
+tests_io_safe_dset_float_hdf5_LDFLAGS = -no-install
+tests_io_str_hdf5_LDFLAGS = -no-install
+tests_io_dset_str_hdf5_LDFLAGS = -no-install
+tests_overwrite_all_hdf5_LDFLAGS = -no-install
+
+endif
+
 
 test_trexio_f = $(srcdir)/tests/trexio_f.f90
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -61,11 +61,9 @@ SOURCES = \
   src/trexio_text.c \
   src/trexio_text.h
 
-if DO_HDF5 
-
+if HAVE_HDF5 
 SOURCES += src/trexio_hdf5.c \
            src/trexio_hdf5.h 
-
 endif
 
 ORG_FILES = \
@@ -90,8 +88,7 @@ TESTS_C = \
   tests/overwrite_all_text \
   tests/io_all
 
-if DO_HDF5 
-
+if HAVE_HDF5 
 TESTS_C += \
   tests/open_hdf5 \
   tests/io_num_hdf5 \
@@ -101,7 +98,6 @@ TESTS_C += \
   tests/io_str_hdf5 \
   tests/io_dset_str_hdf5 \
   tests/overwrite_all_hdf5 
-
 endif
 
 TESTS_F = \
@@ -125,8 +121,7 @@ tests_io_dset_str_text_LDFLAGS = -no-install
 tests_overwrite_all_text_LDFLAGS = -no-install
 tests_io_all_LDFLAGS = -no-install
 
-if DO_HDF5 
-
+if HAVE_HDF5
 tests_open_hdf5_LDFLAGS = -no-install
 tests_io_num_hdf5_LDFLAGS = -no-install
 tests_io_dset_float_hdf5_LDFLAGS = -no-install
@@ -135,7 +130,6 @@ tests_io_safe_dset_float_hdf5_LDFLAGS = -no-install
 tests_io_str_hdf5_LDFLAGS = -no-install
 tests_io_dset_str_hdf5_LDFLAGS = -no-install
 tests_overwrite_all_hdf5_LDFLAGS = -no-install
-
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TREX library for efficient I/O.
 - Autotools             (autoconf >= 2.69, automake >= 1.11, libtool >= 2.2)
 - C compiler            (gcc/icc/clang)
 - Fortran compiler      (gfortran/ifort)
-- HDF5 library          (>= 1.8)
+- HDF5 library          (>= 1.8)	[optional, recommended for high performance]
 
 
 ## Installation procedure from the tarball (for users):
@@ -45,6 +45,13 @@ TREX library for efficient I/O.
 6. `make check`
 7. `sudo make install`
 
+## Compilation without the HDF5 library
+
+By default, the configuration step proceeds to search for the [HDF5 library](https://portal.hdfgroup.org/display/HDF5/HDF5).
+This search can be disabled if HDF5 is not present/installable on the user machine.
+To compile without HDF5, append `--without-hdf5` option to `configure` script. For example,
+
+`./configure --without-hdf5`
 
 ## Linking to your program
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,13 +14,9 @@ AC_CONFIG_MACRO_DIR([m4])
 VERSION_MAJOR=`echo ${PACKAGE_VERSION} | cut -d. -f1`
 VERSION_MINOR=`echo ${PACKAGE_VERSION} | cut -d. -f2`
 VERSION_PATCH=`echo ${PACKAGE_VERSION} | cut -d. -f3 | cut -d- -f1`
-AC_DEFINE_UNQUOTED(TREXIO_PACKAGE_VERSION, ["${PACKAGE_VERSION}"], [full version])
-AC_DEFINE_UNQUOTED(TREXIO_VERSION_MAJOR, [$VERSION_MAJOR], [major version])
-AC_DEFINE_UNQUOTED(TREXIO_VERSION_MINOR, [$VERSION_MINOR], [minor version])
-AC_DEFINE_UNQUOTED(TREXIO_VERSION_PATCH, [$VERSION_PATCH], [patch version])
-AC_SUBST([VERSION_MAJOR])
-AC_SUBST([VERSION_MINOR])
-AC_SUBST([VERSION_PATCH])
+AC_DEFINE_UNQUOTED(VERSION_MAJOR, [$VERSION_MAJOR], [major version])
+AC_DEFINE_UNQUOTED(VERSION_MINOR, [$VERSION_MINOR], [minor version])
+AC_DEFINE_UNQUOTED(VERSION_PATCH, [$VERSION_PATCH], [patch version])
 
 ## Save system information, e.g. user name
 
@@ -109,6 +105,8 @@ PKG_LIBS="${HDF5_LIBS}"
 AC_SUBST([PKG_HDF5])
 AC_SUBST([PKG_CFLAGS])
 AC_SUBST([PKG_LIBS])
+
+AM_CONDITIONAL([DO_HDF5],[test "$with_hdf5" = "yes"])
 
 # The block below should only execute if the ax_lib_hdf5.m4 macro failed to find HDF5.
 # It is only needed to manually build Python API because setup.py depends on HDF5.
@@ -203,7 +201,7 @@ CC ............:  ${CC}
 CPPFLAGS ......:  ${CPPFLAGS}
 CFLAGS ........:  ${CFLAGS}
 FC ............:  ${FC}
-FCLAGS ........:  ${FCFLAGS}
+FCFLAGS .......:  ${FCFLAGS}
 LDFLAGS .......:  ${LDFLAGS}
 LIBS ..........:  ${LIBS}
 

--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ AC_SUBST([PKG_HDF5])
 AC_SUBST([PKG_CFLAGS])
 AC_SUBST([PKG_LIBS])
 
-AM_CONDITIONAL([DO_HDF5],[test "$with_hdf5" = "yes"])
+AM_CONDITIONAL([HAVE_HDF5],[test "$with_hdf5" = "yes"])
 
 # The block below should only execute if the ax_lib_hdf5.m4 macro failed to find HDF5.
 # It is only needed to manually build Python API because setup.py depends on HDF5.

--- a/python/test/test_pytrexio.py
+++ b/python/test/test_pytrexio.py
@@ -9,7 +9,7 @@ from pytrexio.pytrexio import *
 #=========================================================#
 
 # 0: TREXIO_HDF5 ; 1: TREXIO_TEXT
-TEST_TREXIO_BACKEND = 1
+TEST_TREXIO_BACKEND = 0
 OUTPUT_FILENAME_TEXT = 'test_py_swig.dir'
 OUTPUT_FILENAME_HDF5 = 'test_py_swig.h5'
 
@@ -34,7 +34,16 @@ except:
 #============ WRITE THE DATA IN THE TEST FILE ============#
 #=========================================================#
 
-test_file = trexio_open(output_filename, 'w', TEST_TREXIO_BACKEND)
+return_obj = trexio_open(output_filename, 'w', TEST_TREXIO_BACKEND)
+assert return_obj is not None
+if isinstance(return_obj, int):
+    print(trexio_string_of_error(return_obj))
+    assert return_obj==0
+else:
+    rc_open = return_obj[1]
+    assert rc_open==0
+    test_file = return_obj[0]
+    assert test_file is not None
 
 nucleus_num = 12
 
@@ -103,7 +112,16 @@ assert rc==0
 #============ READ THE DATA FROM THE TEST FILE ============#
 #==========================================================#
 
-test_file2 = trexio_open(output_filename, 'r', TEST_TREXIO_BACKEND)
+return_obj = trexio_open(output_filename, 'r', TEST_TREXIO_BACKEND)
+assert return_obj is not None
+if isinstance(return_obj, int):
+    print(trexio_string_of_error(return_obj))
+    assert return_obj==0
+else:
+    rc_open = return_obj[1]
+    assert rc_open==0
+    test_file2 = return_obj[0]
+    assert test_file is not None
 
 result = trexio_read_nucleus_num(test_file2)
 assert result[0]==0
@@ -129,7 +147,7 @@ assert rc==23
 #for i in range(nucleus_num):
 #    assert charges2[i]==charges[i]
 
-result_basis = trexio_read_basis_shell_num(test_file2)
+result = trexio_read_basis_shell_num(test_file2)
 assert result[0]==0
 assert result[1]==basis_num
 

--- a/src/templates_front/build.sh
+++ b/src/templates_front/build.sh
@@ -4,19 +4,19 @@
 cat prefix_front.c   > trexio.c
 cat prefix_front.h   > trexio.h
 
+# parse the config-defined version attributes to pass them to Fortran module file
+VERSION_VAL=`grep "PACKAGE_VERSION" ../../include/config.h | cut -d " " -f 3`
+VERSION_MAJOR_VAL=`grep "VERSION_MAJOR" ../../include/config.h | cut -d " " -f 3`
+VERSION_MINOR_VAL=`grep "VERSION_MINOR" ../../include/config.h | cut -d " " -f 3`
+VERSION_PATCH_VAL=`grep "VERSION_PATCH" ../../include/config.h | cut -d " " -f 3`
+
 # grep some usefull constants from the config.h
 echo "" >> trexio.h
-grep "TREXIO_PACKAGE_VERSION" ../../include/config.h >> trexio.h
-grep "TREXIO_VERSION_MAJOR" ../../include/config.h >> trexio.h
-grep "TREXIO_VERSION_MINOR" ../../include/config.h >> trexio.h
-grep "TREXIO_VERSION_PATCH" ../../include/config.h >> trexio.h
+echo "#define TREXIO_PACKAGE_VERSION ${VERSION_VAL}" >> trexio.h
+echo "#define TREXIO_VERSION_MAJOR ${VERSION_MAJOR_VAL}" >> trexio.h
+echo "#define TREXIO_VERSION_MINOR ${VERSION_MINOR_VAL}" >> trexio.h
+echo "#define TREXIO_VERSION_PATCH ${VERSION_PATCH_VAL}" >> trexio.h
 echo "" >> trexio.h
-
-# parse the config-defined version attributes to pass them to Fortran module file
-VERSION_VAL=`grep "TREXIO_PACKAGE_VERSION" ../../include/config.h | cut -d " " -f 3`
-VERSION_MAJOR_VAL=`grep "TREXIO_VERSION_MAJOR" ../../include/config.h | cut -d " " -f 3`
-VERSION_MINOR_VAL=`grep "TREXIO_VERSION_MINOR" ../../include/config.h | cut -d " " -f 3`
-VERSION_PATCH_VAL=`grep "TREXIO_VERSION_PATCH" ../../include/config.h | cut -d " " -f 3`
 
 cat prefix_s_front.h > trexio_s.h
 cat prefix_fortran.f90   > trexio_f.f90

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -25,6 +25,7 @@
 #ifndef TREXIO_H
 #define TREXIO_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 typedef int32_t trexio_exit_code;
@@ -539,7 +540,30 @@ typedef int32_t back_end_t;
 
 #define TREXIO_DELIM            "\n"
    #+end_src
-   
+
+   The helper function ~trexio_has_backend~ returns ~true~ if TREXIO compilation includes a back end provided as an argument; ~false~ otherwise.
+   This is useful due to the fact that HDF5 back end can be disabled at configure step.
+
+   #+begin_src c :tangle prefix_front.h
+bool trexio_has_backend(back_end_t back_end);
+   #+end_src
+
+   #+begin_src c :tangle prefix_front.c
+bool trexio_has_backend(back_end_t back_end) {
+  switch (back_end) {
+    case TREXIO_TEXT:
+      return true;
+    case TREXIO_HDF5:
+#ifdef HAVE_HDF5
+      return true;
+#else
+      return false;
+#endif
+  }
+  return false;
+}   
+   #+end_src
+ 
 *** Fortran
 
   #+begin_src f90 :tangle prefix_fortran.f90
@@ -547,6 +571,17 @@ typedef int32_t back_end_t;
   integer(trexio_backend), parameter :: TREXIO_TEXT = 1
 ! integer(trexio_backend), parameter :: TREXIO_JSON = 2
   integer(trexio_backend), parameter :: TREXIO_INVALID_BACK_END = 2
+  #+end_src
+
+  The function below is a Fortran interface for the aforementioned C-compatible ~trexio_has_backend~ function.
+
+  #+begin_src f90 :tangle prefix_fortran.f90
+interface
+   logical function trexio_has_backend (back_end) bind(C)
+     use, intrinsic :: iso_c_binding
+     integer(4), intent(in), value :: back_end
+   end function trexio_has_backend
+end interface
   #+end_src
 
 *** Python

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -32,6 +32,11 @@ typedef int32_t trexio_exit_code;
 
   #+begin_src c :tangle prefix_front.c :noweb yes
 <<header>>
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
 #include <pthread.h>
 #include <assert.h>
 #include <stdlib.h>
@@ -42,7 +47,9 @@ typedef int32_t trexio_exit_code;
 #include "trexio_private.h"
 #include "trexio_s.h"
 #include "trexio_text.h"
-#include "trexio_hdf5.h"
+#ifdef HAVE_HDF5 
+  #include "trexio_hdf5.h"
+#endif
 /*
 #include "trexio_json.h"
 ,*/
@@ -739,9 +746,11 @@ trexio_open(const char* file_name, const char mode,
     result_tmp = malloc(sizeof(trexio_text_t));
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     result_tmp = malloc(sizeof(trexio_hdf5_t));
     break;
+#endif
 /*
   case TREXIO_JSON:
     result = (trexio_t*) malloc (sizeof(trexio_json_t));
@@ -790,9 +799,11 @@ trexio_open(const char* file_name, const char mode,
     rc = trexio_text_init(result);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_init(result);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_init(result);
@@ -820,9 +831,11 @@ trexio_open(const char* file_name, const char mode,
       rc = trexio_text_write_metadata_package_version(result, TREXIO_PACKAGE_VERSION);
       break;
 
+#ifdef HAVE_HDF5 
     case TREXIO_HDF5:
       rc = trexio_hdf5_write_metadata_package_version(result, TREXIO_PACKAGE_VERSION);
       break;
+#endif 
 /*
     case TREXIO_JSON:
       rc = trexio_json_write_metadata_package_version(result, TREXIO_PACKAGE_VERSION);
@@ -848,9 +861,11 @@ trexio_open(const char* file_name, const char mode,
     rc = trexio_text_lock(result);
     break;
   /* HDF5 v.>=1.10 has file locking activated by default */
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = TREXIO_SUCCESS;
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_lock(result);
@@ -992,9 +1007,11 @@ trexio_close (trexio_t* file)
     rc = trexio_text_deinit(file);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_deinit(file);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_deinit(file);
@@ -1017,9 +1034,11 @@ trexio_close (trexio_t* file)
     rc = trexio_text_unlock(file);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = TREXIO_SUCCESS;
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_unlock(file);
@@ -1201,9 +1220,11 @@ trexio_read_$group_num$_64 (trexio_t* const file, $group_num_dtype_double$* cons
     return trexio_text_read_$group_num$(file, num);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_read_$group_num$(file, num);
     break;
+#endif
 /*
   case TREXIO_JSON:
     return trexio_json_read_$group_num$(file, num);
@@ -1229,9 +1250,11 @@ trexio_write_$group_num$_64 (trexio_t* const file, const $group_num_dtype_double
     return trexio_text_write_$group_num$(file, num);
     break;				       
 					       
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:			       
     return trexio_hdf5_write_$group_num$(file, num);
-    break;				       
+    break;
+#endif
 /*					       
   case TREXIO_JSON:			       
     return trexio_json_write_$group_num$(file, num);
@@ -1261,9 +1284,11 @@ trexio_read_$group_num$_32 (trexio_t* const file, $group_num_dtype_single$* cons
     rc = trexio_text_read_$group_num$(file, &num_64);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_read_$group_num$(file, &num_64);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc =trexio_json_read_$group_num$(file, &num_64);
@@ -1293,9 +1318,11 @@ trexio_write_$group_num$_32 (trexio_t* const file, const $group_num_dtype_single
     return trexio_text_write_$group_num$(file, ($group_num_dtype_double$) num);
     break;					       
 						       
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:				       
     return trexio_hdf5_write_$group_num$(file, ($group_num_dtype_double$) num);
-    break;					       
+    break;
+#endif 
 /*						       
   case TREXIO_JSON:				       
     return trexio_json_write_$group_num$(file, ($group_num_dtype_double$) num);
@@ -1340,9 +1367,11 @@ trexio_has_$group_num$ (trexio_t* const file)
     return trexio_text_has_$group_num$(file);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_has_$group_num$(file);
     break;
+#endif
 /*
   case TREXIO_JSON:
     return trexio_json_has_$group_num$(file);
@@ -1583,9 +1612,11 @@ trexio_read_$group_dset$_64 (trexio_t* const file, $group_dset_dtype_double$* co
     rc = trexio_text_read_$group_dset$(file, $group_dset$, rank, dims);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_read_$group_dset$(file, $group_dset$, rank, dims);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_read_$group_dset$(file, $group_dset$, rank, dims);
@@ -1657,9 +1688,11 @@ trexio_write_$group_dset$_64 (trexio_t* const file, const $group_dset_dtype_doub
     rc = trexio_text_write_$group_dset$(file, $group_dset$_p, rank, dims);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_write_$group_dset$(file, $group_dset$_p, rank, dims);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_write_$group_dset$(file, $group_dset$_p, rank, dims);
@@ -1717,9 +1750,11 @@ trexio_read_$group_dset$_32 (trexio_t* const file, $group_dset_dtype_single$* co
     rc = trexio_text_read_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_read_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_read_$group_dset$(file, $group_dset$_64, rank, dims);
@@ -1796,9 +1831,11 @@ trexio_write_$group_dset$_32 (trexio_t* const file, const $group_dset_dtype_sing
     rc = trexio_text_write_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_write_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_write_$group_dset$(file, $group_dset$_64, rank, dims);
@@ -1960,9 +1997,11 @@ trexio_has_$group_dset$ (trexio_t* const file)
     return trexio_text_has_$group_dset$(file);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_has_$group_dset$(file);
     break;
+#endif
 /*
   case TREXIO_JSON:
     return trexio_json_has_$group_dset$(file);
@@ -2405,9 +2444,11 @@ trexio_read_$group_dset$_low (trexio_t* const file, char* dset_out, const int32_
     return trexio_text_read_$group_dset$(file, dset_out, rank, dims, (uint32_t) max_str_len);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_read_$group_dset$(file, dset_out, rank, dims, (uint32_t) max_str_len);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_read_$group_dset$(file, dset_out, rank, dims);
@@ -2529,9 +2570,11 @@ trexio_write_$group_dset$_low (trexio_t* const file, const char* dset_in, const 
     rc = trexio_text_write_$group_dset$(file, (const char**) dset_str, rank, dims);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     rc = trexio_hdf5_write_$group_dset$(file, (const char**) dset_str, rank, dims);
     break;
+#endif
 /*
   case TREXIO_JSON:
     rc = trexio_json_write_$group_dset$(file, dset, rank, dims);
@@ -2597,9 +2640,11 @@ trexio_has_$group_dset$ (trexio_t* const file)
     return trexio_text_has_$group_dset$(file);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_has_$group_dset$(file);
     break;
+#endif
 /*
   case TREXIO_JSON:
     return trexio_json_has_$group_dset$(file);
@@ -2846,9 +2891,11 @@ trexio_read_$group_str$ (trexio_t* const file, char* const str_out, const int32_
     return trexio_text_read_$group_str$(file, str_out, (uint32_t) max_str_len);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_read_$group_str$(file, str_out, (uint32_t) max_str_len);
     break;
+#endif
 /*
   case TREXIO_JSON:
     return trexio_json_read_$group_str$(file, str);
@@ -2879,9 +2926,11 @@ trexio_write_$group_str$ (trexio_t* const file, const char* str, const int32_t m
     return trexio_text_write_$group_str$(file, str);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_write_$group_str$(file, str);
     break;
+#endif
 /*
   case TREXIO_JSON:
     return trexio_json_write_$group_str$(file, str);
@@ -2908,9 +2957,11 @@ trexio_has_$group_str$ (trexio_t* const file)
     return trexio_text_has_$group_str$(file);
     break;
 
+#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
     return trexio_hdf5_has_$group_str$(file);
     break;
+#endif
 /*
   case TREXIO_JSON:
     return trexio_json_has_$group_str$(file);

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -25,10 +25,6 @@
 #ifndef TREXIO_H
 #define TREXIO_H
 
-#ifdef HAVE_CONFIG_H
-  #include "config.h"
-#endif
-
 #include <stdint.h>
 
 typedef int32_t trexio_exit_code;
@@ -189,6 +185,7 @@ __trexio_path__ = None
    | ~TREXIO_UNSAFE_ARRAY_DIM~    |   23 | 'Access to memory beyond allocated'    |
    | ~TREXIO_ATTR_MISSING~        |   24 | 'Attribute does not exist in the file' |
    | ~TREXIO_DSET_MISSING~        |   25 | 'Dataset does not exist in the file'   |
+   | ~TREXIO_BACK_END_MISSING~    |   26 | 'Requested back end is disabled'       |
    | ~TREXIO_INVALID_STR_LEN~     |   30 | 'Invalid max_str_len'                  |
 
    # We need to force Emacs not to indent the Python code:
@@ -228,7 +225,7 @@ return '\n'.join(result)
 
 
    #+RESULTS:
-   :results:
+   :RESULTS:
    #+begin_src c :tangle prefix_front.h :exports none
    #define TREXIO_FAILURE                 ((trexio_exit_code) -1)
    #define TREXIO_SUCCESS                 ((trexio_exit_code) 0)
@@ -257,6 +254,7 @@ return '\n'.join(result)
    #define TREXIO_UNSAFE_ARRAY_DIM        ((trexio_exit_code) 23)
    #define TREXIO_ATTR_MISSING            ((trexio_exit_code) 24)
    #define TREXIO_DSET_MISSING            ((trexio_exit_code) 25)
+   #define TREXIO_BACK_END_MISSING        ((trexio_exit_code) 26)
    #define TREXIO_INVALID_STR_LEN         ((trexio_exit_code) 30)
    #+end_src
 
@@ -288,6 +286,7 @@ return '\n'.join(result)
       integer(trexio_exit_code), parameter :: TREXIO_UNSAFE_ARRAY_DIM        = 23
       integer(trexio_exit_code), parameter :: TREXIO_ATTR_MISSING            = 24
       integer(trexio_exit_code), parameter :: TREXIO_DSET_MISSING            = 25
+      integer(trexio_exit_code), parameter :: TREXIO_BACK_END_MISSING        = 26
       integer(trexio_exit_code), parameter :: TREXIO_INVALID_STR_LEN         = 30
    #+end_src
 
@@ -320,9 +319,10 @@ return '\n'.join(result)
    TREXIO_UNSAFE_ARRAY_DIM        = 23
    TREXIO_ATTR_MISSING            = 24
    TREXIO_DSET_MISSING            = 25
+   TREXIO_BACK_END_MISSING        = 26
    TREXIO_INVALID_STR_LEN         = 30
    #+end_src
-   :end:
+   :END:
  
 *** Decoding errors
 
@@ -532,23 +532,19 @@ def string_of_error(return_code: int) -> str:
    #+begin_src c :tangle prefix_front.h
 typedef int32_t back_end_t;
 
-#define TREXIO_TEXT             ( (back_end_t) 0 )
-#ifdef HAVE_HDF5
-#define TREXIO_HDF5             ( (back_end_t) 1 )
+#define TREXIO_HDF5             ( (back_end_t) 0 )
+#define TREXIO_TEXT             ( (back_end_t) 1 )
 #define TREXIO_INVALID_BACK_END ( (back_end_t) 2 )
-#else
-#define TREXIO_INVALID_BACK_END ( (back_end_t) 1 )
-#endif
 /*#define TREXIO_JSON             ( (back_end_t) 2 )*/
 
 #define TREXIO_DELIM            "\n"
    #+end_src
-
+   
 *** Fortran
 
   #+begin_src f90 :tangle prefix_fortran.f90
-  integer(trexio_backend), parameter :: TREXIO_TEXT = 0
-  integer(trexio_backend), parameter :: TREXIO_HDF5 = 1
+  integer(trexio_backend), parameter :: TREXIO_HDF5 = 0 
+  integer(trexio_backend), parameter :: TREXIO_TEXT = 1
 ! integer(trexio_backend), parameter :: TREXIO_JSON = 2
   integer(trexio_backend), parameter :: TREXIO_INVALID_BACK_END = 2
   #+end_src
@@ -557,12 +553,12 @@ typedef int32_t back_end_t;
 
   #+begin_src python :tangle prefix_python.py
 # define TREXIO back ends
-TREXIO_TEXT = 0
-TREXIO_HDF5 = 1
+TREXIO_HDF5 = 0 
+TREXIO_TEXT = 1
 #TREXIO_JSON = 2
 TREXIO_INVALID_BACK_END = 2
   #+end_src
-
+  
 ** Read/write behavior
 
    Every time a reading function is called, the data is read from the
@@ -754,10 +750,13 @@ trexio_open(const char* file_name, const char mode,
     result_tmp = malloc(sizeof(trexio_text_t));
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     result_tmp = malloc(sizeof(trexio_hdf5_t));
     break;
+#else
+    if (rc_open != NULL) *rc_open = TREXIO_BACK_END_MISSING;
+    return NULL;
 #endif
 /*
   case TREXIO_JSON:
@@ -807,10 +806,13 @@ trexio_open(const char* file_name, const char mode,
     rc = trexio_text_init(result);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_init(result);
     break;
+#else
+    if (rc_open != NULL) *rc_open = TREXIO_BACK_END_MISSING;
+    return NULL;
 #endif
 /*
   case TREXIO_JSON:
@@ -839,10 +841,13 @@ trexio_open(const char* file_name, const char mode,
       rc = trexio_text_write_metadata_package_version(result, TREXIO_PACKAGE_VERSION);
       break;
 
-#ifdef HAVE_HDF5 
     case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
       rc = trexio_hdf5_write_metadata_package_version(result, TREXIO_PACKAGE_VERSION);
       break;
+#else
+      if (rc_open != NULL) *rc_open = TREXIO_BACK_END_MISSING;
+      return NULL;
 #endif 
 /*
     case TREXIO_JSON:
@@ -869,10 +874,13 @@ trexio_open(const char* file_name, const char mode,
     rc = trexio_text_lock(result);
     break;
   /* HDF5 v.>=1.10 has file locking activated by default */
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = TREXIO_SUCCESS;
     break;
+#else
+    if (rc_open != NULL) *rc_open = TREXIO_BACK_END_MISSING;
+    return NULL;
 #endif
 /*
   case TREXIO_JSON:
@@ -1015,10 +1023,12 @@ trexio_close (trexio_t* file)
     rc = trexio_text_deinit(file);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_deinit(file);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1042,10 +1052,12 @@ trexio_close (trexio_t* file)
     rc = trexio_text_unlock(file);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = TREXIO_SUCCESS;
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1228,10 +1240,12 @@ trexio_read_$group_num$_64 (trexio_t* const file, $group_num_dtype_double$* cons
     return trexio_text_read_$group_num$(file, num);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_read_$group_num$(file, num);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1258,10 +1272,12 @@ trexio_write_$group_num$_64 (trexio_t* const file, const $group_num_dtype_double
     return trexio_text_write_$group_num$(file, num);
     break;				       
 					       
+  case TREXIO_HDF5:
 #ifdef HAVE_HDF5 
-  case TREXIO_HDF5:			       
     return trexio_hdf5_write_$group_num$(file, num);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*					       
   case TREXIO_JSON:			       
@@ -1292,10 +1308,12 @@ trexio_read_$group_num$_32 (trexio_t* const file, $group_num_dtype_single$* cons
     rc = trexio_text_read_$group_num$(file, &num_64);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_read_$group_num$(file, &num_64);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1326,10 +1344,12 @@ trexio_write_$group_num$_32 (trexio_t* const file, const $group_num_dtype_single
     return trexio_text_write_$group_num$(file, ($group_num_dtype_double$) num);
     break;					       
 						       
+  case TREXIO_HDF5:
 #ifdef HAVE_HDF5 
-  case TREXIO_HDF5:				       
     return trexio_hdf5_write_$group_num$(file, ($group_num_dtype_double$) num);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif 
 /*						       
   case TREXIO_JSON:				       
@@ -1375,10 +1395,12 @@ trexio_has_$group_num$ (trexio_t* const file)
     return trexio_text_has_$group_num$(file);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_has_$group_num$(file);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1620,10 +1642,12 @@ trexio_read_$group_dset$_64 (trexio_t* const file, $group_dset_dtype_double$* co
     rc = trexio_text_read_$group_dset$(file, $group_dset$, rank, dims);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_read_$group_dset$(file, $group_dset$, rank, dims);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1696,10 +1720,12 @@ trexio_write_$group_dset$_64 (trexio_t* const file, const $group_dset_dtype_doub
     rc = trexio_text_write_$group_dset$(file, $group_dset$_p, rank, dims);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_write_$group_dset$(file, $group_dset$_p, rank, dims);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1758,10 +1784,12 @@ trexio_read_$group_dset$_32 (trexio_t* const file, $group_dset_dtype_single$* co
     rc = trexio_text_read_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_read_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -1839,10 +1867,12 @@ trexio_write_$group_dset$_32 (trexio_t* const file, const $group_dset_dtype_sing
     rc = trexio_text_write_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_write_$group_dset$(file, $group_dset$_64, rank, dims);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -2005,10 +2035,12 @@ trexio_has_$group_dset$ (trexio_t* const file)
     return trexio_text_has_$group_dset$(file);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_has_$group_dset$(file);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -2452,10 +2484,12 @@ trexio_read_$group_dset$_low (trexio_t* const file, char* dset_out, const int32_
     return trexio_text_read_$group_dset$(file, dset_out, rank, dims, (uint32_t) max_str_len);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_read_$group_dset$(file, dset_out, rank, dims, (uint32_t) max_str_len);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -2578,10 +2612,12 @@ trexio_write_$group_dset$_low (trexio_t* const file, const char* dset_in, const 
     rc = trexio_text_write_$group_dset$(file, (const char**) dset_str, rank, dims);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     rc = trexio_hdf5_write_$group_dset$(file, (const char**) dset_str, rank, dims);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -2648,10 +2684,12 @@ trexio_has_$group_dset$ (trexio_t* const file)
     return trexio_text_has_$group_dset$(file);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_has_$group_dset$(file);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -2899,10 +2937,12 @@ trexio_read_$group_str$ (trexio_t* const file, char* const str_out, const int32_
     return trexio_text_read_$group_str$(file, str_out, (uint32_t) max_str_len);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_read_$group_str$(file, str_out, (uint32_t) max_str_len);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -2934,10 +2974,12 @@ trexio_write_$group_str$ (trexio_t* const file, const char* str, const int32_t m
     return trexio_text_write_$group_str$(file, str);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_write_$group_str$(file, str);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:
@@ -2965,10 +3007,12 @@ trexio_has_$group_str$ (trexio_t* const file)
     return trexio_text_has_$group_str$(file);
     break;
 
-#ifdef HAVE_HDF5 
   case TREXIO_HDF5:
+#ifdef HAVE_HDF5 
     return trexio_hdf5_has_$group_str$(file);
     break;
+#else
+    return TREXIO_BACK_END_MISSING;
 #endif
 /*
   case TREXIO_JSON:

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -25,6 +25,10 @@
 #ifndef TREXIO_H
 #define TREXIO_H
 
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
 #include <stdint.h>
 
 typedef int32_t trexio_exit_code;
@@ -528,10 +532,14 @@ def string_of_error(return_code: int) -> str:
    #+begin_src c :tangle prefix_front.h
 typedef int32_t back_end_t;
 
-#define TREXIO_HDF5             ( (back_end_t) 0 )
-#define TREXIO_TEXT             ( (back_end_t) 1 )
-/*#define TREXIO_JSON             ( (back_end_t) 2 )*/
+#define TREXIO_TEXT             ( (back_end_t) 0 )
+#ifdef HAVE_HDF5
+#define TREXIO_HDF5             ( (back_end_t) 1 )
 #define TREXIO_INVALID_BACK_END ( (back_end_t) 2 )
+#else
+#define TREXIO_INVALID_BACK_END ( (back_end_t) 1 )
+#endif
+/*#define TREXIO_JSON             ( (back_end_t) 2 )*/
 
 #define TREXIO_DELIM            "\n"
    #+end_src
@@ -539,8 +547,8 @@ typedef int32_t back_end_t;
 *** Fortran
 
   #+begin_src f90 :tangle prefix_fortran.f90
-  integer(trexio_backend), parameter :: TREXIO_HDF5 = 0
-  integer(trexio_backend), parameter :: TREXIO_TEXT = 1
+  integer(trexio_backend), parameter :: TREXIO_TEXT = 0
+  integer(trexio_backend), parameter :: TREXIO_HDF5 = 1
 ! integer(trexio_backend), parameter :: TREXIO_JSON = 2
   integer(trexio_backend), parameter :: TREXIO_INVALID_BACK_END = 2
   #+end_src
@@ -549,8 +557,8 @@ typedef int32_t back_end_t;
 
   #+begin_src python :tangle prefix_python.py
 # define TREXIO back ends
-TREXIO_HDF5 = 0
-TREXIO_TEXT = 1
+TREXIO_TEXT = 0
+TREXIO_HDF5 = 1
 #TREXIO_JSON = 2
 TREXIO_INVALID_BACK_END = 2
   #+end_src

--- a/tests/io_all.c
+++ b/tests/io_all.c
@@ -1,3 +1,7 @@
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
 #include "trexio.h"
 #include <assert.h>
 #include <stdio.h>
@@ -12,12 +16,14 @@ int main() {
 /*============== Main test launcher ================*/
 
   int rc;
-  rc = system("rm -rf test_all.h5");
+#ifdef HAVE_HDF5
+  rc = system("rm -f test_all.h5");
   assert (rc == 0);
   test_write("test_all.h5", TREXIO_HDF5);
   test_read ("test_all.h5", TREXIO_HDF5);
-  rc = system("rm -rf test_all.h5");
+  rc = system("rm -f test_all.h5");
   assert (rc == 0);
+#endif
 
   rc = system("rm -rf test_all.dir");
   assert (rc == 0);

--- a/tests/io_all.c
+++ b/tests/io_all.c
@@ -1,7 +1,4 @@
 
-#ifdef HAVE_CONFIG_H
-  #include "config.h"
-#endif
 #include "trexio.h"
 #include <assert.h>
 #include <stdio.h>
@@ -16,14 +13,16 @@ int main() {
 /*============== Main test launcher ================*/
 
   int rc;
-#ifdef HAVE_HDF5
-  rc = system("rm -f test_all.h5");
-  assert (rc == 0);
-  test_write("test_all.h5", TREXIO_HDF5);
-  test_read ("test_all.h5", TREXIO_HDF5);
-  rc = system("rm -f test_all.h5");
-  assert (rc == 0);
-#endif
+
+  bool have_hdf5 = trexio_has_backend(TREXIO_HDF5);
+  if(have_hdf5) {
+    rc = system("rm -f -- test_all.h5");
+    assert (rc == 0);
+    test_write("test_all.h5", TREXIO_HDF5);
+    test_read ("test_all.h5", TREXIO_HDF5);
+    rc = system("rm -f -- test_all.h5");
+    assert (rc == 0);
+  }
 
   rc = system("rm -rf test_all.dir");
   assert (rc == 0);

--- a/tests/test_f.f90
+++ b/tests/test_f.f90
@@ -1,6 +1,9 @@
 program test_trexio
   use trexio
+  use, intrinsic :: iso_c_binding
   implicit none
+  
+  logical :: have_hdf5
 
   print *      , "============================================" 
   print'(a,a)' , "         TREXIO VERSION STRING : ", TREXIO_PACKAGE_VERSION 
@@ -19,14 +22,17 @@ program test_trexio
 
   ! No way to conditionally check whether compilation was done with HDF5 
   ! So temporarily disable the test for HDF5 back end at the moment
-! call system('rm -rf test_write_f.h5')
-! print *, 'call test_write(''test_write_f.h5'', TREXIO_HDF5)'
-! call test_write('test_write_f.h5', TREXIO_HDF5)
-! print *, 'call test_read(''test_write_f.h5'', TREXIO_HDF5)'
-! call test_read('test_write_f.h5', TREXIO_HDF5)
-! call system('rm -rf test_write_f.h5')
-! 
-! call test_read_void('test_write_f.h5', TREXIO_HDF5)
+  have_hdf5 = trexio_has_backend(TREXIO_HDF5)
+  if (have_hdf5) then
+    call system('rm -f -- test_write_f.h5')
+    print *, 'call test_write(''test_write_f.h5'', TREXIO_HDF5)'
+    call test_write('test_write_f.h5', TREXIO_HDF5)
+    print *, 'call test_read(''test_write_f.h5'', TREXIO_HDF5)'
+    call test_read('test_write_f.h5', TREXIO_HDF5)
+    call system('rm -f -- test_write_f.h5')
+    
+    call test_read_void('test_write_f.h5', TREXIO_HDF5)
+  endif
 
 end program test_trexio
 

--- a/tests/test_f.f90
+++ b/tests/test_f.f90
@@ -17,14 +17,16 @@ program test_trexio
 
   call test_read_void('test_write_f.dir', TREXIO_TEXT)
 
-  call system('rm -rf test_write_f.h5')
-  print *, 'call test_write(''test_write_f.h5'', TREXIO_HDF5)'
-  call test_write('test_write_f.h5', TREXIO_HDF5)
-  print *, 'call test_read(''test_write_f.h5'', TREXIO_HDF5)'
-  call test_read('test_write_f.h5', TREXIO_HDF5)
-  call system('rm -rf test_write_f.h5')
-  
-  call test_read_void('test_write_f.h5', TREXIO_HDF5)
+  ! No way to conditionally check whether compilation was done with HDF5 
+  ! So temporarily disable the test for HDF5 back end at the moment
+! call system('rm -rf test_write_f.h5')
+! print *, 'call test_write(''test_write_f.h5'', TREXIO_HDF5)'
+! call test_write('test_write_f.h5', TREXIO_HDF5)
+! print *, 'call test_read(''test_write_f.h5'', TREXIO_HDF5)'
+! call test_read('test_write_f.h5', TREXIO_HDF5)
+! call system('rm -rf test_write_f.h5')
+! 
+! call test_read_void('test_write_f.h5', TREXIO_HDF5)
 
 end program test_trexio
 

--- a/tools/prepare_python.sh
+++ b/tools/prepare_python.sh
@@ -29,6 +29,11 @@ cp ${SRC}/*.c ${PYDIR}/src
 cp ${SRC}/*.h ${PYDIR}/src
 cp ${INCLUDIR}/trexio.h ${PYDIR}/src 
 
+# fix needed to define HAVE_HDF5 symbol so that Python extension is always compiled with HDF5 (without including config.h)
+# add "#define HAVE_HDF5 1" line after "#include stdint.h" using awk and sed
+LINE_NO=$(($(awk '/stdint.h/{print NR}' ${PYDIR}/src/trexio.h) + 1))
+sed -i "$LINE_NO i #define HAVE_HDF5 1" ${PYDIR}/src/trexio.h 
+
 # Copy additional info
 cp ${TREXIO_ROOT}/AUTHORS ${TREXIO_ROOT}/LICENSE ${PYDIR}
 


### PR DESCRIPTION
Introduced optional calls to HDF5 back end using the `#ifdef HAVE_HDF5` pre-processor macro, which value is defined by `configure` script in `config.h` file. 

By default, `./configure` proceeds to search for the HDF5 library. To disable this, provide `--without-hdf5` argument. For example,

`./configure --without-hdf5`  