### PR TITLE
CMake compilation as a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,9 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Optional configure for developer mode to generate source code from org-mode files.
 option(TREXIO_DEVEL "TREXIO developer mode (for code generation)." OFF)
+option(TREXIO_TESTS "Whether to perform tests for TREXIO" ON)
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/.devel")
+if(EXISTS "${PROJECT_SOURCE_DIR}/.devel")
   set(TREXIO_DEVEL ON)
   find_package(Python3 REQUIRED)
   if(Python3_FOUND)
@@ -48,8 +49,8 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.devel")
   set(TREXIO_USER_NAME $ENV{USER})
   # replace placeholders in the templace config.h.in file to produce config.h
   # config.h is needed to insert TREXIO_PACKAGE_VERSION and TREXIO_GIT_HASH into trexio.h
-  configure_file(${CMAKE_SOURCE_DIR}/include/cmake_config.h.in
-                 ${CMAKE_SOURCE_DIR}/include/config.h
+  configure_file(${PROJECT_SOURCE_DIR}/include/cmake_config.h.in
+                 ${PROJECT_SOURCE_DIR}/include/config.h
 		 @ONLY)
 endif()
 
@@ -60,5 +61,7 @@ include_directories(include)
 add_subdirectory(src)
 
 # Add subdirectory with unit tests.
-enable_testing()
-add_subdirectory(tests)
+if(TREXIO_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/cmake/FindTREXIO.cmake
+++ b/cmake/FindTREXIO.cmake
@@ -11,6 +11,7 @@
 # $ export TREXIO_DIR=<custom_path>
 # to indicate the prefix used during the TREXIO installation
 # (typically `./configure prefix=<custom_path> ..` or `cmake -DCMAKE_INSTALL_DIR=<custom_path> ..`)
+# Alternatively, TREXIO_DIR can be provided in a CMake cache.
 
 # This file should be located WITHIN your project source tree.
 # (e.g. in cmake/FindTREXIO.cmake)
@@ -45,9 +46,13 @@ set(TREXIO_SEARCH_PATHS
 	/opt
 )
 
+if (NOT TREXIO_DIR)
+  set(TREXIO_DIR $ENV{TREXIO_DIR})
+endif()
+
 find_path(TREXIO_INCLUDE_DIR
 	  NAMES trexio.h
-	  HINTS $ENV{TREXIO_DIR}
+    HINTS "${TREXIO_DIR}"
 	  PATH_SUFFIXES include/trexio include
 	  PATHS ${TREXIO_SEARCH_PATHS}
 	  )
@@ -57,7 +62,7 @@ find_path(TREXIO_INCLUDE_DIR
 # suffix (e.g. .so on Unix or .dylib on MacOS) in NAMES. CMake takes care of that.
 find_library(TREXIO_LIBRARY
              NAMES trexio
-	     HINTS $ENV{TREXIO_DIR}
+	     HINTS "${TREXIO_DIR}"
 	     PATH_SUFFIXES lib64 lib
 	     PATHS ${TREXIO_SEARCH_PATHS}
 	     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ set(TREXIO_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/trexio.c
 	${CMAKE_CURRENT_SOURCE_DIR}/trexio_text.c
 	)
-set(TREXIO_PUBLIC_HEADERS ${CMAKE_SOURCE_DIR}/include/trexio.h)
+set(TREXIO_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/trexio.h)
 set(TREXIO_PRIVATE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/trexio_s.h
 	${CMAKE_CURRENT_SOURCE_DIR}/trexio_private.h
@@ -101,7 +101,7 @@ include(FortranCInterface)
 FortranCInterface_VERIFY()
 
 # Fortran module
-set(TREXIO_MOD_FILE ${CMAKE_SOURCE_DIR}/include/trexio_f.f90)
+set(TREXIO_MOD_FILE ${PROJECT_SOURCE_DIR}/include/trexio_f.f90)
 # Export to parent scope so tests directory picks this up.
 set(TREXIO_MOD_FILE ${TREXIO_MOD_FILE} PARENT_SCOPE)
 # Add TREXIO Fortran module as a library.
@@ -115,7 +115,7 @@ if(TREXIO_DEVEL)
   set(ORG_FILES
 	templates_front/templator_front.org
   	templates_text/templator_text.org
-	${CMAKE_SOURCE_DIR}/trex.org
+    ${PROJECT_SOURCE_DIR}/trex.org
 	)
   if(ENABLE_HDF5)
     list(APPEND ORG_FILES templates_hdf5/templator_hdf5.org)
@@ -127,8 +127,8 @@ if(TREXIO_DEVEL)
 	  ${TREXIO_PRIVATE_HEADERS}
 	  ${TREXIO_MOD_FILE}
       COMMAND ./build_trexio.sh
-      DEPENDS ${ORG_FILES} ${CMAKE_SOURCE_DIR}/include/config.h
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tools
+      DEPENDS ${ORG_FILES} ${PROJECT_SOURCE_DIR}/include/config.h
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools
       COMMENT "Generating TREXIO source code from org-mode files."
       VERBATIM)
 
@@ -156,7 +156,7 @@ install(FILES ${TREXIO_MOD_FILE} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 # https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
 if(NOT TARGET uninstall)
   configure_file(
-    "${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${PROJECT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
     IMMEDIATE @ONLY)
 


### PR DESCRIPTION
Hello everyone,

when compiling trexio with CMake as a subdirectory of a larger project, e.g. with the following structure:

Project/
&nbsp;&nbsp;src/
&nbsp;&nbsp;external/
&nbsp;&nbsp;&nbsp;&nbsp;trexio/

including trexio in the root CMakeLists.txt as ```add_subdirectory(external/trexio)``` has ```CMAKE_SOURCE_DIR``` pointing to ```Project``` instead of ```Project/external/trexio``` which breaks functionality. It is fixed by using ```PROJECT_SOURCE_DIR``` instead, which is identical to ```CMAKE_SOURCE_DIR``` if trexio is installed on its own.

Furthermore, I made ```FindTREXIO.cmake``` check whether ```TREXIO_DIR``` is set as a CMake variable before loading it from the environment variable.