### PR TITLE
Added kpoint to MO group

### DIFF
--- a/trex.org
+++ b/trex.org
@@ -135,8 +135,9 @@
    :results:
    #+begin_src python :tangle trex.json
        "pbc": {
-           "periodic" : [ "int"  , []      ]
-         ,  "k_point" : [ "float", [ "3" ] ]
+              "periodic" : [ "int"  , []                         ]
+         , "k_point_num" : [ "dim"  , []                         ]
+         ,     "k_point" : [ "float", [ "pbc.k_point_num", "3" ] ]
        } ,
    #+end_src
    :end:
@@ -841,7 +842,7 @@ power = [
          ,     "occupation" : [ "float", [ "mo.num" ]           ]
          ,         "energy" : [ "float", [ "mo.num" ]           ]
          ,           "spin" : [ "int"  , [ "mo.num" ]           ]
-         ,         "kpoint" : [ "int"  , [ "mo.num" ]           ]
+         ,        "k_point" : [ "index", [ "mo.num" ]           ]
        } ,
    #+end_src
    :end:

--- a/trex.org
+++ b/trex.org
@@ -121,14 +121,13 @@
 
 ** Periodic boundary calculations (pbc group)
 
-   A single $k$-point per TREXIO file can be stored. The $k$-point is
-   defined in this group.
 
    #+NAME: pbc
-   | Variable   | Type    | Dimensions | Description             |
-   |------------+---------+------------+-------------------------|
-   | ~periodic~ | ~int~   |            | ~1~: true or ~0~: false |
-   | ~k_point~  | ~float~ | ~(3)~      | $k$-point sampling      |
+   | Variable      | Type    | Dimensions             | Description             |
+   |---------------+---------+------------------------+-------------------------|
+   | ~periodic~    | ~int~   |                        | ~1~: true or ~0~: false |
+   | ~k_point_num~ | ~dim~   |                        | Number of $k$-points    |
+   | ~k_point~     | ~float~ | ~(3, pbc.k_point_num)~ | $k$-point sampling      |
 
    #+CALL: json(data=pbc, title="pbc")
 
@@ -819,7 +818,7 @@ power = [
    | ~occupation~     | ~float~ | ~(mo.num)~         | Occupation number                                                        |
    | ~energy~         | ~float~ | ~(mo.num)~         | For canonical MOs, corresponding eigenvalue                              |
    | ~spin~           | ~int~   | ~(mo.num)~         | For UHF wave functions, 0 is $\alpha$ and 1 is $\beta$                   |
-   | ~kpoint~         | ~int~   | ~(mo.num)~         | For periodic calculations, the $k$ point to which each MO belongs        |
+   | ~k_point~        | ~index~ | ~(mo.num)~         | For periodic calculations, the $k$ point to which each MO belongs        |
 
    **Warning**: ~mo.num~ is the total number of MOs stored in the file.
    For periodic calculations, this group contains all the MOs

--- a/trex.org
+++ b/trex.org
@@ -123,11 +123,12 @@
 
 
    #+NAME: pbc
-   | Variable      | Type    | Dimensions             | Description             |
-   |---------------+---------+------------------------+-------------------------|
-   | ~periodic~    | ~int~   |                        | ~1~: true or ~0~: false |
-   | ~k_point_num~ | ~dim~   |                        | Number of $k$-points    |
-   | ~k_point~     | ~float~ | ~(3, pbc.k_point_num)~ | $k$-point sampling      |
+   | Variable         | Type    | Dimensions             | Description             |
+   |------------------+---------+------------------------+-------------------------|
+   | ~periodic~       | ~int~   |                        | ~1~: true or ~0~: false |
+   | ~k_point_num~    | ~dim~   |                        | Number of $k$-points    |
+   | ~k_point~        | ~float~ | ~(3, pbc.k_point_num)~ | $k$-point sampling      |
+   | ~k_point_weight~ | ~float~ | ~(pbc.k_point_num)~    | $k$-point weight        |
 
    #+CALL: json(data=pbc, title="pbc")
 
@@ -135,9 +136,10 @@
    :results:
    #+begin_src python :tangle trex.json
        "pbc": {
-              "periodic" : [ "int"  , []                         ]
-         , "k_point_num" : [ "dim"  , []                         ]
-         ,     "k_point" : [ "float", [ "pbc.k_point_num", "3" ] ]
+                 "periodic" : [ "int"  , []                         ]
+         ,    "k_point_num" : [ "dim"  , []                         ]
+         ,        "k_point" : [ "float", [ "pbc.k_point_num", "3" ] ]
+         , "k_point_weight" : [ "float", [ "pbc.k_point_num" ]      ]
        } ,
    #+end_src
    :end:

--- a/trex.org
+++ b/trex.org
@@ -326,32 +326,32 @@
 *** Data definitions
 
     #+NAME: basis
-    | Variable            | Type    | Dimensions                                   | Description                                                                  |   |
-    |---------------------+---------+----------------------------------------------+------------------------------------------------------------------------------+---|
-    | ~type~              | ~str~   |                                              | Type of basis set: "Gaussian", "Slater", "Numerical" or "PW" for plane waves |   |
-    | ~prim_num~          | ~dim~   |                                              | Total number of primitives                                                   |   |
-    | ~shell_num~         | ~dim~   |                                              | Total number of shells                                                       |   |
-    | ~nao_grid_num~       | ~dim~   |                                              | Total number of grid points for numerical orbitals                           |   |
-    | ~interp_coeff_cnt~  | ~dim~   |                                              | Number of coefficients for the numerical orbital interpolator                |   |
-    | ~nucleus_index~     | ~index~ | ~(basis.shell_num)~                          | One-to-one correspondence between shells and atomic indices                  |   |
-    | ~shell_ang_mom~     | ~int~   | ~(basis.shell_num)~                          | One-to-one correspondence between shells and angular momenta                 |   |
-    | ~shell_factor~      | ~float~ | ~(basis.shell_num)~                          | Normalization factor of each shell ($\mathcal{N}_s$)                         |   |
-    | ~r_power~           | ~int~   | ~(basis.shell_num)~                          | Power to which $r$ is raised ($n_s$)                                         |   |
-    | ~nao_grid_start~     | ~index~ | ~(basis.shell_num)~                          | Index of the first data point for a given numerical orbital                  |   |
-    | ~nao_grid_size~      | ~dim~   | ~(basis.shell_num)~                          | Number of data points per numerical orbital                                  |   |
-    | ~shell_index~       | ~index~ | ~(basis.prim_num)~                           | One-to-one correspondence between primitives and shell index                 |   |
-    | ~exponent~          | ~float~ | ~(basis.prim_num)~                           | Exponents of the primitives ($\gamma_{ks}$)                                  |   |
-    | ~coefficient~       | ~float~ | ~(basis.prim_num)~                           | Coefficients of the primitives ($a_{ks}$)                                    |   |
-    | ~prim_factor~       | ~float~ | ~(basis.prim_num)~                           | Normalization coefficients for the primitives ($f_{ks}$)                     |   |
-    | ~e_cut~             | ~float~ |                                              | Energy cut-off for plane-wave calculations                                   |   |
-    | ~nao_grid_radius~    | ~float~ | ~(basis.nao_grid_num)~                        | Radii of grid points for numerical orbitals                                  |   |
-    | ~nao_grid_phi~       | ~float~ | ~(basis.nao_grid_num)~                        | Wave function values for numerical orbitals                                  |   |
-    | ~nao_grid_grad~      | ~float~ | ~(basis.nao_grid_num)~                        | Radial gradient of numerical orbitals                                        |   |
-    | ~nao_grid_lap~       | ~float~ | ~(basis.nao_grid_num)~                        | Laplacian of numerical orbitals                                              |   |
-    | ~interpolator_kind~ | ~str~   |                                              | Kind of spline, e.g. "Polynomial"                                            |   |
-    | ~interpolator_phi~  | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital interpolation function                    |   |
-    | ~interpolator_grad~ | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital gradient interpolation function           |   |
-    | ~interpolator_lap~  | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital laplacian interpolation function          |   |
+    | Variable            | Type    | Dimensions                                    | Description                                                                  |
+    |---------------------+---------+-----------------------------------------------+------------------------------------------------------------------------------|
+    | ~type~              | ~str~   |                                               | Type of basis set: "Gaussian", "Slater", "Numerical" or "PW" for plane waves |
+    | ~prim_num~          | ~dim~   |                                               | Total number of primitives                                                   |
+    | ~shell_num~         | ~dim~   |                                               | Total number of shells                                                       |
+    | ~nao_grid_num~      | ~dim~   |                                               | Total number of grid points for numerical orbitals                           |
+    | ~interp_coeff_cnt~  | ~dim~   |                                               | Number of coefficients for the numerical orbital interpolator                |
+    | ~nucleus_index~     | ~index~ | ~(basis.shell_num)~                           | One-to-one correspondence between shells and atomic indices                  |
+    | ~shell_ang_mom~     | ~int~   | ~(basis.shell_num)~                           | One-to-one correspondence between shells and angular momenta                 |
+    | ~shell_factor~      | ~float~ | ~(basis.shell_num)~                           | Normalization factor of each shell ($\mathcal{N}_s$)                         |
+    | ~r_power~           | ~int~   | ~(basis.shell_num)~                           | Power to which $r$ is raised ($n_s$)                                         |
+    | ~nao_grid_start~    | ~index~ | ~(basis.shell_num)~                           | Index of the first data point for a given numerical orbital                  |
+    | ~nao_grid_size~     | ~dim~   | ~(basis.shell_num)~                           | Number of data points per numerical orbital                                  |
+    | ~shell_index~       | ~index~ | ~(basis.prim_num)~                            | One-to-one correspondence between primitives and shell index                 |
+    | ~exponent~          | ~float~ | ~(basis.prim_num)~                            | Exponents of the primitives ($\gamma_{ks}$)                                  |
+    | ~coefficient~       | ~float~ | ~(basis.prim_num)~                            | Coefficients of the primitives ($a_{ks}$)                                    |
+    | ~prim_factor~       | ~float~ | ~(basis.prim_num)~                            | Normalization coefficients for the primitives ($f_{ks}$)                     |
+    | ~e_cut~             | ~float~ |                                               | Energy cut-off for plane-wave calculations                                   |
+    | ~nao_grid_radius~   | ~float~ | ~(basis.nao_grid_num)~                        | Radii of grid points for numerical orbitals                                  |
+    | ~nao_grid_phi~      | ~float~ | ~(basis.nao_grid_num)~                        | Wave function values for numerical orbitals                                  |
+    | ~nao_grid_grad~     | ~float~ | ~(basis.nao_grid_num)~                        | Radial gradient of numerical orbitals                                        |
+    | ~nao_grid_lap~      | ~float~ | ~(basis.nao_grid_num)~                        | Laplacian of numerical orbitals                                              |
+    | ~interpolator_kind~ | ~str~   |                                               | Kind of spline, e.g. "Polynomial"                                            |
+    | ~interpolator_phi~  | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital interpolation function                    |
+    | ~interpolator_grad~ | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital gradient interpolation function           |
+    | ~interpolator_lap~  | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital laplacian interpolation function          |
 
 
 
@@ -811,7 +811,7 @@ power = [
    | Variable         | Type    | Dimensions         | Description                                                              |
    |------------------+---------+--------------------+--------------------------------------------------------------------------|
    | ~type~           | ~str~   |                    | Free text to identify the set of MOs (HF, Natural, Local, CASSCF, /etc/) |
-   | ~num~            | ~dim~   |                    | Number of MOs                                                            |
+   | ~num~            | ~dim~   |                    | Number of MOs stored in the file                                         |
    | ~coefficient~    | ~float~ | ~(ao.num, mo.num)~ | MO coefficients                                                          |
    | ~coefficient_im~ | ~float~ | ~(ao.num, mo.num)~ | MO coefficients (imaginary part)                                         |
    | ~class~          | ~str~   | ~(mo.num)~         | Choose among: Core, Inactive, Active, Virtual, Deleted                   |
@@ -819,7 +819,14 @@ power = [
    | ~occupation~     | ~float~ | ~(mo.num)~         | Occupation number                                                        |
    | ~energy~         | ~float~ | ~(mo.num)~         | For canonical MOs, corresponding eigenvalue                              |
    | ~spin~           | ~int~   | ~(mo.num)~         | For UHF wave functions, 0 is $\alpha$ and 1 is $\beta$                   |
+   | ~kpoint~         | ~int~   | ~(mo.num)~         | For periodic calculations, the $k$ point to which each MO belongs        |
 
+   **Warning**: ~mo.num~ is the total number of MOs stored in the file.
+   For periodic calculations, this group contains all the MOs
+   belonging to all $k$ points so ~mo.num~ will be the sum of the
+   numbers of MOs in each $k$ point. For UHF wave functions, ~mo.num~
+   is the number of spin-orbitals, twice the number of spatial orbitals.
+   
    #+CALL: json(data=mo, title="mo")
 
    #+RESULTS:
@@ -835,9 +842,11 @@ power = [
          ,     "occupation" : [ "float", [ "mo.num" ]           ]
          ,         "energy" : [ "float", [ "mo.num" ]           ]
          ,           "spin" : [ "int"  , [ "mo.num" ]           ]
+         ,         "kpoint" : [ "int"  , [ "mo.num" ]           ]
        } ,
    #+end_src
    :end:
+
 
 *** One-electron integrals (~mo_1e_int~ group)
 
@@ -1325,19 +1334,19 @@ power = [
 *** Table of values
 
    #+name: jastrow
-  | Variable      | Type     | Dimensions          | Description                                                     |
-  |---------------+----------+---------------------+-----------------------------------------------------------------|
-  | ~type~        | ~str~ |                     | Type of Jastrow factor: ~CHAMP~ or ~Mu~                         |
-  | ~en_num~      | ~dim~    |                     | Number of Electron-nucleus parameters                           |
-  | ~ee_num~      | ~dim~    |                     | Number of Electron-electron parameters                          |
-  | ~een_num~     | ~dim~    |                     | Number of Electron-electron-nucleus parameters                  |
-  | ~en~          | ~float~  | ~(jastrow.en_num)~  | Electron-nucleus parameters                                     |
-  | ~ee~          | ~float~  | ~(jastrow.ee_num)~  | Electron-electron parameters                                    |
-  | ~een~         | ~float~  | ~(jastrow.een_num)~ | Electron-electron-nucleus parameters                            |
-  | ~en_nucleus~  | ~index~  | ~(jastrow.en_num)~  | Nucleus relative to the eN parameter                            |
-  | ~een_nucleus~ | ~index~  | ~(jastrow.een_num)~ | Nucleus relative to the eeN parameter                           |
-  | ~ee_scaling~  | ~float~  |                     | $\kappa$ value in CHAMP Jastrow for electron-electron distances |
-  | ~en_scaling~  | ~float~  | ~(nucleus.num)~     | $\kappa$ value in CHAMP Jastrow for electron-nucleus distances  |
+  | Variable      | Type    | Dimensions          | Description                                                     |
+  |---------------+---------+---------------------+-----------------------------------------------------------------|
+  | ~type~        | ~str~   |                     | Type of Jastrow factor: ~CHAMP~ or ~Mu~                         |
+  | ~en_num~      | ~dim~   |                     | Number of Electron-nucleus parameters                           |
+  | ~ee_num~      | ~dim~   |                     | Number of Electron-electron parameters                          |
+  | ~een_num~     | ~dim~   |                     | Number of Electron-electron-nucleus parameters                  |
+  | ~en~          | ~float~ | ~(jastrow.en_num)~  | Electron-nucleus parameters                                     |
+  | ~ee~          | ~float~ | ~(jastrow.ee_num)~  | Electron-electron parameters                                    |
+  | ~een~         | ~float~ | ~(jastrow.een_num)~ | Electron-electron-nucleus parameters                            |
+  | ~en_nucleus~  | ~index~ | ~(jastrow.en_num)~  | Nucleus relative to the eN parameter                            |
+  | ~een_nucleus~ | ~index~ | ~(jastrow.een_num)~ | Nucleus relative to the eeN parameter                           |
+  | ~ee_scaling~  | ~float~ |                     | $\kappa$ value in CHAMP Jastrow for electron-electron distances |
+  | ~en_scaling~  | ~float~ | ~(nucleus.num)~     | $\kappa$ value in CHAMP Jastrow for electron-nucleus distances  |
 
    #+CALL: json(data=jastrow, title="jastrow")
 
@@ -1345,17 +1354,17 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "jastrow": {
-                  "type" : [ "str"   , []                    ]
-         ,      "en_num" : [ "dim"   , []                    ]
-         ,      "ee_num" : [ "dim"   , []                    ]
-         ,     "een_num" : [ "dim"   , []                    ]
-         ,          "en" : [ "float" , [ "jastrow.en_num" ]  ]
-         ,          "ee" : [ "float" , [ "jastrow.ee_num" ]  ]
-         ,         "een" : [ "float" , [ "jastrow.een_num" ] ]
-         ,  "en_nucleus" : [ "index" , [ "jastrow.en_num" ]  ]
-         , "een_nucleus" : [ "index" , [ "jastrow.een_num" ] ]
-         ,  "ee_scaling" : [ "float" , []                    ]
-         ,  "en_scaling" : [ "float" , [ "nucleus.num" ]     ]
+                  "type" : [ "str"  , []                    ]
+         ,      "en_num" : [ "dim"  , []                    ]
+         ,      "ee_num" : [ "dim"  , []                    ]
+         ,     "een_num" : [ "dim"  , []                    ]
+         ,          "en" : [ "float", [ "jastrow.en_num" ]  ]
+         ,          "ee" : [ "float", [ "jastrow.ee_num" ]  ]
+         ,         "een" : [ "float", [ "jastrow.een_num" ] ]
+         ,  "en_nucleus" : [ "index", [ "jastrow.en_num" ]  ]
+         , "een_nucleus" : [ "index", [ "jastrow.een_num" ] ]
+         ,  "ee_scaling" : [ "float", []                    ]
+         ,  "en_scaling" : [ "float", [ "nucleus.num" ]     ]
        } ,
    #+end_src
    :end:


### PR DESCRIPTION
I have added an array `kpoint` to the MO group.
With this modification, the users can store all the MOs of all kpoints in a single file. This is necessary because for correlated calculations (CI or CC), it is necessary to have 2-electron integrals involving MOs of different kpoints.
With this modification, it is possible to extend the format to correlated periodic calculations without breaking backwards compatibility.
