### PR TITLE
Added 1e and 2e transition density matrices for GammCor

### DIFF
--- a/trex.org
+++ b/trex.org
@@ -326,29 +326,29 @@
 *** Data definitions
 
     #+NAME: basis
-    | Variable            | Type    | Dimensions                                   | Description                                                                  |   |
-    |---------------------+---------+----------------------------------------------+------------------------------------------------------------------------------+---|
-    | ~type~              | ~str~   |                                              | Type of basis set: "Gaussian", "Slater", "Numerical" or "PW" for plane waves |   |
-    | ~prim_num~          | ~dim~   |                                              | Total number of primitives                                                   |   |
-    | ~shell_num~         | ~dim~   |                                              | Total number of shells                                                       |   |
-    | ~nao_grid_num~       | ~dim~   |                                              | Total number of grid points for numerical orbitals                           |   |
-    | ~interp_coeff_cnt~  | ~dim~   |                                              | Number of coefficients for the numerical orbital interpolator                |   |
-    | ~nucleus_index~     | ~index~ | ~(basis.shell_num)~                          | One-to-one correspondence between shells and atomic indices                  |   |
-    | ~shell_ang_mom~     | ~int~   | ~(basis.shell_num)~                          | One-to-one correspondence between shells and angular momenta                 |   |
-    | ~shell_factor~      | ~float~ | ~(basis.shell_num)~                          | Normalization factor of each shell ($\mathcal{N}_s$)                         |   |
-    | ~r_power~           | ~int~   | ~(basis.shell_num)~                          | Power to which $r$ is raised ($n_s$)                                         |   |
-    | ~nao_grid_start~     | ~index~ | ~(basis.shell_num)~                          | Index of the first data point for a given numerical orbital                  |   |
-    | ~nao_grid_size~      | ~dim~   | ~(basis.shell_num)~                          | Number of data points per numerical orbital                                  |   |
-    | ~shell_index~       | ~index~ | ~(basis.prim_num)~                           | One-to-one correspondence between primitives and shell index                 |   |
-    | ~exponent~          | ~float~ | ~(basis.prim_num)~                           | Exponents of the primitives ($\gamma_{ks}$)                                  |   |
-    | ~coefficient~       | ~float~ | ~(basis.prim_num)~                           | Coefficients of the primitives ($a_{ks}$)                                    |   |
-    | ~prim_factor~       | ~float~ | ~(basis.prim_num)~                           | Normalization coefficients for the primitives ($f_{ks}$)                     |   |
-    | ~e_cut~             | ~float~ |                                              | Energy cut-off for plane-wave calculations                                   |   |
-    | ~nao_grid_radius~    | ~float~ | ~(basis.nao_grid_num)~                        | Radii of grid points for numerical orbitals                                  |   |
-    | ~nao_grid_phi~       | ~float~ | ~(basis.nao_grid_num)~                        | Wave function values for numerical orbitals                                  |   |
-    | ~nao_grid_grad~      | ~float~ | ~(basis.nao_grid_num)~                        | Radial gradient of numerical orbitals                                        |   |
-    | ~nao_grid_lap~       | ~float~ | ~(basis.nao_grid_num)~                        | Laplacian of numerical orbitals                                              |   |
-    | ~interpolator_kind~ | ~str~   |                                              | Kind of spline, e.g. "Polynomial"                                            |   |
+    | Variable            | Type    | Dimensions                                    | Description                                                                  |   |
+    |---------------------+---------+-----------------------------------------------+------------------------------------------------------------------------------+---|
+    | ~type~              | ~str~   |                                               | Type of basis set: "Gaussian", "Slater", "Numerical" or "PW" for plane waves |   |
+    | ~prim_num~          | ~dim~   |                                               | Total number of primitives                                                   |   |
+    | ~shell_num~         | ~dim~   |                                               | Total number of shells                                                       |   |
+    | ~nao_grid_num~      | ~dim~   |                                               | Total number of grid points for numerical orbitals                           |   |
+    | ~interp_coeff_cnt~  | ~dim~   |                                               | Number of coefficients for the numerical orbital interpolator                |   |
+    | ~nucleus_index~     | ~index~ | ~(basis.shell_num)~                           | One-to-one correspondence between shells and atomic indices                  |   |
+    | ~shell_ang_mom~     | ~int~   | ~(basis.shell_num)~                           | One-to-one correspondence between shells and angular momenta                 |   |
+    | ~shell_factor~      | ~float~ | ~(basis.shell_num)~                           | Normalization factor of each shell ($\mathcal{N}_s$)                         |   |
+    | ~r_power~           | ~int~   | ~(basis.shell_num)~                           | Power to which $r$ is raised ($n_s$)                                         |   |
+    | ~nao_grid_start~    | ~index~ | ~(basis.shell_num)~                           | Index of the first data point for a given numerical orbital                  |   |
+    | ~nao_grid_size~     | ~dim~   | ~(basis.shell_num)~                           | Number of data points per numerical orbital                                  |   |
+    | ~shell_index~       | ~index~ | ~(basis.prim_num)~                            | One-to-one correspondence between primitives and shell index                 |   |
+    | ~exponent~          | ~float~ | ~(basis.prim_num)~                            | Exponents of the primitives ($\gamma_{ks}$)                                  |   |
+    | ~coefficient~       | ~float~ | ~(basis.prim_num)~                            | Coefficients of the primitives ($a_{ks}$)                                    |   |
+    | ~prim_factor~       | ~float~ | ~(basis.prim_num)~                            | Normalization coefficients for the primitives ($f_{ks}$)                     |   |
+    | ~e_cut~             | ~float~ |                                               | Energy cut-off for plane-wave calculations                                   |   |
+    | ~nao_grid_radius~   | ~float~ | ~(basis.nao_grid_num)~                        | Radii of grid points for numerical orbitals                                  |   |
+    | ~nao_grid_phi~      | ~float~ | ~(basis.nao_grid_num)~                        | Wave function values for numerical orbitals                                  |   |
+    | ~nao_grid_grad~     | ~float~ | ~(basis.nao_grid_num)~                        | Radial gradient of numerical orbitals                                        |   |
+    | ~nao_grid_lap~      | ~float~ | ~(basis.nao_grid_num)~                        | Laplacian of numerical orbitals                                              |   |
+    | ~interpolator_kind~ | ~str~   |                                               | Kind of spline, e.g. "Polynomial"                                            |   |
     | ~interpolator_phi~  | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital interpolation function                    |   |
     | ~interpolator_grad~ | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital gradient interpolation function           |   |
     | ~interpolator_lap~  | ~float~ | ~(basis.interp_coeff_cnt,basis.nao_grid_num)~ | Coefficients for numerical orbital laplacian interpolation function          |   |
@@ -1124,23 +1124,25 @@ power = [
    $g_{ik}(\mathbf{r}_1) = \phi_i(\mathbf{r}_1) \phi_k(\mathbf{r}_1)$.
 
    #+NAME: rdm
-   | Variable               | Type           | Dimensions                                   | Description                                                           |
-   |------------------------+----------------+----------------------------------------------+-----------------------------------------------------------------------|
-   | ~1e~                   | ~float~        | ~(mo.num, mo.num)~                           | One body density matrix                                               |
-   | ~1e_up~                | ~float~        | ~(mo.num, mo.num)~                           | \uparrow-spin component of the one body density matrix                |
-   | ~1e_dn~                | ~float~        | ~(mo.num, mo.num)~                           | \downarrow-spin component of the one body density matrix              |
-   | ~2e~                   | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~           | Two-body reduced density matrix (spin trace)                          |
-   | ~2e_upup~              | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~           | \uparrow\uparrow component of the two-body reduced density matrix     |
-   | ~2e_dndn~              | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~           | \downarrow\downarrow component of the two-body reduced density matrix |
-   | ~2e_updn~              | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~           | \uparrow\downarrow component of the two-body reduced density matrix   |
-   | ~2e_cholesky_num~      | ~dim~          |                                              | Number of Cholesky vectors                                            |
-   | ~2e_cholesky~          | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_cholesky_num)~      | Cholesky decomposition of the two-body RDM (spin trace)               |
-   | ~2e_upup_cholesky_num~ | ~dim~          |                                              | Number of Cholesky vectors                                            |
-   | ~2e_upup_cholesky~     | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_upup_cholesky_num)~ | Cholesky decomposition of the two-body RDM (\uparrow\uparrow)         |
-   | ~2e_dndn_cholesky_num~ | ~dim~          |                                              | Number of Cholesky vectors                                            |
-   | ~2e_dndn_cholesky~     | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_dndn_cholesky_num)~ | Cholesky decomposition of the two-body RDM (\downarrow\downarrow)     |
-   | ~2e_updn_cholesky_num~ | ~dim~          |                                              | Number of Cholesky vectors                                            |
-   | ~2e_updn_cholesky~     | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_updn_cholesky_num)~ | Cholesky decomposition of the two-body RDM (\uparrow\downarrow)       |
+   | Variable               | Type           | Dimensions                                              | Description                                                           |
+   |------------------------+----------------+---------------------------------------------------------+-----------------------------------------------------------------------|
+   | ~1e~                   | ~float~        | ~(mo.num, mo.num)~                                      | One body density matrix                                               |
+   | ~1e_up~                | ~float~        | ~(mo.num, mo.num)~                                      | \uparrow-spin component of the one body density matrix                |
+   | ~1e_dn~                | ~float~        | ~(mo.num, mo.num)~                                      | \downarrow-spin component of the one body density matrix              |
+   | ~1e_transition~        | ~float~        | ~(mo.num, mo.num, state.num, state.num)                 | One-particle transition density matrices                              |
+   | ~2e~                   | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~                      | Two-body reduced density matrix (spin trace)                          |
+   | ~2e_upup~              | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~                      | \uparrow\uparrow component of the two-body reduced density matrix     |
+   | ~2e_dndn~              | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~                      | \downarrow\downarrow component of the two-body reduced density matrix |
+   | ~2e_updn~              | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num)~                      | \uparrow\downarrow component of the two-body reduced density matrix   |
+   | ~2e_transition~        | ~float sparse~ | ~(mo.num, mo.num, mo.num, mo.num, state.num, state.num) | Two-particle transition density matrices                              |
+   | ~2e_cholesky_num~      | ~dim~          |                                                         | Number of Cholesky vectors                                            |
+   | ~2e_cholesky~          | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_cholesky_num)~                 | Cholesky decomposition of the two-body RDM (spin trace)               |
+   | ~2e_upup_cholesky_num~ | ~dim~          |                                                         | Number of Cholesky vectors                                            |
+   | ~2e_upup_cholesky~     | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_upup_cholesky_num)~            | Cholesky decomposition of the two-body RDM (\uparrow\uparrow)         |
+   | ~2e_dndn_cholesky_num~ | ~dim~          |                                                         | Number of Cholesky vectors                                            |
+   | ~2e_dndn_cholesky~     | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_dndn_cholesky_num)~            | Cholesky decomposition of the two-body RDM (\downarrow\downarrow)     |
+   | ~2e_updn_cholesky_num~ | ~dim~          |                                                         | Number of Cholesky vectors                                            |
+   | ~2e_updn_cholesky~     | ~float sparse~ | ~(mo.num, mo.num, rdm.2e_updn_cholesky_num)~            | Cholesky decomposition of the two-body RDM (\uparrow\downarrow)       |
 
    #+CALL: json(data=rdm, title="rdm")
 
@@ -1148,21 +1150,23 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "rdm": {
-                             "1e" : [ "float"       , [ "mo.num", "mo.num" ]                             ]
-         ,                "1e_up" : [ "float"       , [ "mo.num", "mo.num" ]                             ]
-         ,                "1e_dn" : [ "float"       , [ "mo.num", "mo.num" ]                             ]
-         ,                   "2e" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]         ]
-         ,              "2e_upup" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]         ]
-         ,              "2e_dndn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]         ]
-         ,              "2e_updn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]         ]
-         ,      "2e_cholesky_num" : [ "dim"         , []                                                 ]
-         ,          "2e_cholesky" : [ "float sparse", [ "rdm.2e_cholesky_num", "mo.num", "mo.num" ]      ]
-         , "2e_upup_cholesky_num" : [ "dim"         , []                                                 ]
-         ,     "2e_upup_cholesky" : [ "float sparse", [ "rdm.2e_upup_cholesky_num", "mo.num", "mo.num" ] ]
-         , "2e_dndn_cholesky_num" : [ "dim"         , []                                                 ]
-         ,     "2e_dndn_cholesky" : [ "float sparse", [ "rdm.2e_dndn_cholesky_num", "mo.num", "mo.num" ] ]
-         , "2e_updn_cholesky_num" : [ "dim"         , []                                                 ]
-         ,     "2e_updn_cholesky" : [ "float sparse", [ "rdm.2e_updn_cholesky_num", "mo.num", "mo.num" ] ]
+                             "1e" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
+         ,                "1e_up" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
+         ,                "1e_dn" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
+         ,        "1e_transition" : [ "float"       , [ "state.num", "state.num", "mo.num", "mo.num" ]                     ]
+         ,                   "2e" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+         ,              "2e_upup" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+         ,              "2e_dndn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+         ,              "2e_updn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+         ,        "2e_transition" : [ "float sparse", [ "state.num", "state.num", "mo.num", "mo.num", "mo.num", "mo.num" ] ]
+         ,      "2e_cholesky_num" : [ "dim"         , []                                                                   ]
+         ,          "2e_cholesky" : [ "float sparse", [ "rdm.2e_cholesky_num", "mo.num", "mo.num" ]                        ]
+         , "2e_upup_cholesky_num" : [ "dim"         , []                                                                   ]
+         ,     "2e_upup_cholesky" : [ "float sparse", [ "rdm.2e_upup_cholesky_num", "mo.num", "mo.num" ]                   ]
+         , "2e_dndn_cholesky_num" : [ "dim"         , []                                                                   ]
+         ,     "2e_dndn_cholesky" : [ "float sparse", [ "rdm.2e_dndn_cholesky_num", "mo.num", "mo.num" ]                   ]
+         , "2e_updn_cholesky_num" : [ "dim"         , []                                                                   ]
+         ,     "2e_updn_cholesky" : [ "float sparse", [ "rdm.2e_updn_cholesky_num", "mo.num", "mo.num" ]                   ]
        } ,
    #+end_src
    :end:
@@ -1325,19 +1329,19 @@ power = [
 *** Table of values
 
    #+name: jastrow
-  | Variable      | Type     | Dimensions          | Description                                                     |
-  |---------------+----------+---------------------+-----------------------------------------------------------------|
-  | ~type~        | ~str~ |                     | Type of Jastrow factor: ~CHAMP~ or ~Mu~                         |
-  | ~en_num~      | ~dim~    |                     | Number of Electron-nucleus parameters                           |
-  | ~ee_num~      | ~dim~    |                     | Number of Electron-electron parameters                          |
-  | ~een_num~     | ~dim~    |                     | Number of Electron-electron-nucleus parameters                  |
-  | ~en~          | ~float~  | ~(jastrow.en_num)~  | Electron-nucleus parameters                                     |
-  | ~ee~          | ~float~  | ~(jastrow.ee_num)~  | Electron-electron parameters                                    |
-  | ~een~         | ~float~  | ~(jastrow.een_num)~ | Electron-electron-nucleus parameters                            |
-  | ~en_nucleus~  | ~index~  | ~(jastrow.en_num)~  | Nucleus relative to the eN parameter                            |
-  | ~een_nucleus~ | ~index~  | ~(jastrow.een_num)~ | Nucleus relative to the eeN parameter                           |
-  | ~ee_scaling~  | ~float~  |                     | $\kappa$ value in CHAMP Jastrow for electron-electron distances |
-  | ~en_scaling~  | ~float~  | ~(nucleus.num)~     | $\kappa$ value in CHAMP Jastrow for electron-nucleus distances  |
+  | Variable      | Type    | Dimensions          | Description                                                     |
+  |---------------+---------+---------------------+-----------------------------------------------------------------|
+  | ~type~        | ~str~   |                     | Type of Jastrow factor: ~CHAMP~ or ~Mu~                         |
+  | ~en_num~      | ~dim~   |                     | Number of Electron-nucleus parameters                           |
+  | ~ee_num~      | ~dim~   |                     | Number of Electron-electron parameters                          |
+  | ~een_num~     | ~dim~   |                     | Number of Electron-electron-nucleus parameters                  |
+  | ~en~          | ~float~ | ~(jastrow.en_num)~  | Electron-nucleus parameters                                     |
+  | ~ee~          | ~float~ | ~(jastrow.ee_num)~  | Electron-electron parameters                                    |
+  | ~een~         | ~float~ | ~(jastrow.een_num)~ | Electron-electron-nucleus parameters                            |
+  | ~en_nucleus~  | ~index~ | ~(jastrow.en_num)~  | Nucleus relative to the eN parameter                            |
+  | ~een_nucleus~ | ~index~ | ~(jastrow.een_num)~ | Nucleus relative to the eeN parameter                           |
+  | ~ee_scaling~  | ~float~ |                     | $\kappa$ value in CHAMP Jastrow for electron-electron distances |
+  | ~en_scaling~  | ~float~ | ~(nucleus.num)~     | $\kappa$ value in CHAMP Jastrow for electron-nucleus distances  |
 
    #+CALL: json(data=jastrow, title="jastrow")
 


### PR DESCRIPTION
I added just 2 entries in the rdm group: `1e_transition` and `2e_transition`
All the other differences are formatting of tables.