### PR TITLE
Fix errors in latex formating of equations in Numerical orbitals

### DIFF
--- a/trex.org
+++ b/trex.org
@@ -276,10 +276,10 @@
     Laplacian easily as follows:
 
     \[
-      \grad_{x_i} \phi = \frac{x_i}{r^2}\left u\prime(r) - \frac{u(r)}{r}\right
+      \nabla_{x_i} \phi = \frac{x_i}{r^2}\left( u^\prime\left(r\right) - \frac{u\left(r\right)}{r}\right)
     \]
     \[
-      \Delta \phi = \frac{1}{r^3}\left x^2 u''(r) + \left3x^2-r^2\right \left \frac{u(r)}{r^2} - \frac{u'(r)}{r}\right \right
+      \Delta \phi = \frac{1}{r^3}\left(x^2 u^{\prime\prime}(r) + \left( 3x^2-r^2\right) \left( \frac{u(r)}{r^2} - \frac{u'(r)}{r}\right) \right)
     \]
 
     The index of the first data point for each shell is stored in 
@@ -303,7 +303,7 @@
     \]
     where
     \[
-    c = \log\left \frac{r_1}{r_0}\right.
+    c = \log\left(\frac{r_1}{r_0}\right)
     \]
     For convenience, this conversion and functions to evaluate the splines
     are provided with trexio. Since these implementations are not adapted to


### PR DESCRIPTION
I discovered on github pages some equation were not rendered at all due to error in latex code. I fix them, but I hope I did not introduced and error. Personally I don't like $x^2$ in expression of Laplacian.  Can someone check it out?