### PR TITLE
Fix interface return type and remove unused dummy argument

### DIFF
--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -4521,7 +4521,7 @@ end interface
      if (rc /= TREXIO_SUCCESS) then
        trexio_write_$group_dset$ = rc
      else
-       call trexio_strarray2str(dset, $group_dset_dim$, max_str_len, str_compiled)
+       call trexio_strarray2str(dset, $group_dset_dim$, str_compiled)
        trexio_write_$group_dset$ = trexio_write_$group_dset$_low(trex_file, str_compiled, max_str_len)
      endif
 
@@ -6332,9 +6332,9 @@ trexio_mark_safety (trexio_t* const file, const int32_t safety_flag)
 
    #+begin_src f90 :tangle prefix_fortran.f90
 interface
-   integer function trexio_info () bind(C)
+   integer(c_int32_t) function trexio_info_c () bind(C, name="trexio_info")
      use, intrinsic :: iso_c_binding
-   end function trexio_info
+   end function trexio_info_c
 end interface
    #+end_src
 
@@ -6647,13 +6647,20 @@ def evaluate_nao_radial_all(nucleus_index, nucleus_coords, grid_start,
 
 * Fortran helper/wrapper functions
 
+  #+begin_src f90 :tangle helper_fortran.f90
+contains
+   integer function trexio_info ()
+     implicit none
+     trexio_info = trexio_info_c()
+   end function trexio_info
+  #+end_src
+
   The function below adapts the original C-based ~trexio_open~ for Fortran.
   This is needed due to the fact that strings in C are terminated by ~NULL~ character ~\0~
   unlike strings in Fortran.
   Note, that Fortran interface calls the main ~TREXIO~ API, which is written in C.
 
   #+begin_src f90 :tangle helper_fortran.f90
-contains
    integer(trexio_t) function trexio_open (filename, mode, back_end, rc_open)
      use, intrinsic :: iso_c_binding, only : c_null_char
      implicit none
@@ -6790,12 +6797,11 @@ contains
   C API. This is needed due to the fact that strings in C are terminated by ~NULL~ character ~\0~.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   subroutine trexio_strarray2str(str_array, max_num_str, max_len_str, str_res)
+   subroutine trexio_strarray2str(str_array, max_num_str, str_res)
      use, intrinsic :: iso_c_binding, only : c_null_char
      implicit none
 
-     integer(c_int64_t), intent(in), value   :: max_num_str  ! number of elements in strign array
-     integer, intent(in), value   :: max_len_str  ! maximum length of a string in an array
+     integer(c_int64_t), intent(in), value   :: max_num_str  ! number of elements in string array
      character(len=*), intent(in)  :: str_array(*)
      character(len=:), allocatable, intent(out) :: str_res
      integer(c_int64_t) :: i


### PR DESCRIPTION
This PR fixes two problems with the Fortran API that I encountered while integrating TREXIO into CP2K:

1. The interface to `function trexio_info()` was returning an `integer` rather than a `c_int32_t`. To fix it @scemama and I used the same trick used for `function trexio_open`.
2. The `subroutine trexio_strarray2str` had an unused dummy argument, `max_str_len`, which we removed from the signature and for the relevant subroutine calls.
