### PR TITLE
Add codes supporting TREXIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Below is the list of codes that adopted TREXIO for reading and/or writing single
 | [Quantum Package](https://github.com/QuantumPackage/qp2)                       | Write/Read       | Write/Read      |
 | [FHI-aims](https://fhi-aims.org/)                                              | Write/Read       | ??              |
 | [PySCF](https://github.com/pyscf/pyscf)                                        | Write/Read       | Write/Read      |
-| [CP2K](https://github.com/cp2k/cp2k)                                           | Write/Read       | ---             |
+| [CP2K](https://github.com/cp2k/cp2k)                                           | Write            | ---             |
 | [CHAMP](https://github.com/filippi-claudia/champ)                              | Read             | Read            |
 | [GammCor](https://github.com/pernalk/GAMMCOR)                                  | Read             | Read            |
 | [TurboRVB](https://github.com/sissaschool/turborvb)                            | Read             | ---             |
 | [ipie](https://github.com/JoonhoLee-Group/ipie)                                | Read             | ??              |
-| [Spicy](https://gitlab.com/theoretical-chemistry-jena/quantum-chemistry/Spicy) | Read             | ??              |
+| [Spicy](https://gitlab.com/theoretical-chemistry-jena/quantum-chemistry/Spicy) | Read             | ---             |
 | [QMC=Chem](https://github.com/TREX-CoE/qmcchem2)                               | Read             | Read            |
 | [QMCkl](https://github.com/TREX-CoE/qmckl)                                     | Read             | ---             |
 

--- a/README.md
+++ b/README.md
@@ -15,30 +15,47 @@ which enables fast read and write operations. It is compatible with a variety
 of platforms and has interfaces for the Fortran, Python, OCaml and Rust
 programming languages.
 
+Below is the list of codes that adopted TREXIO for reading and/or writing single- and/or multi-reference wave functions:
+
+| Software                                                                       | Single-reference | Multi-reference |
+| ------------------------------------------------------------------------------ | ---------------- | --------------- |
+| [Quantum Package](https://github.com/QuantumPackage/qp2)                       | Write/Read       | Write/Read      |
+| [FHI-aims](https://fhi-aims.org/)                                              | Write/Read       | ??              |
+| [PySCF](https://github.com/pyscf/pyscf)                                        | Write/Read       | Write/Read      |
+| [CP2K](https://github.com/cp2k/cp2k)                                           | Write/Read       | ---             |
+| [CHAMP](https://github.com/filippi-claudia/champ)                              | Read             | Read            |
+| [GammCor](https://github.com/pernalk/GAMMCOR)                                  | Read             | Read            |
+| [TurboRVB](https://github.com/sissaschool/turborvb)                            | Read             | ---             |
+| [ipie](https://github.com/JoonhoLee-Group/ipie)                                | Read             | ??              |
+| [Spicy](https://gitlab.com/theoretical-chemistry-jena/quantum-chemistry/Spicy) | Read             | ??              |
+| [QMC=Chem](https://github.com/TREX-CoE/qmcchem2)                               | Read             | Read            |
+| [QMCkl](https://github.com/TREX-CoE/qmckl)                                     | Read             | ---             |
+
+
 * [Installation](#installation)
-   * [Installation using a package manager](#installation-using-a-package-manager)
-      * [Conda](#conda)
-      * [Spack](#spack)
-      * [Guix](#guix)
-      * [Debian/Ubuntu](#debianubuntu)
-   * [Installation from source](#installation-from-source)
-      * [Minimal requirements (for users):](#minimal-requirements-for-users)
-      * [Recommended: Installation from the release tarball](#recommended-installation-from-the-release-tarball)
-      * [Compilation without the HDF5 library](#compilation-without-the-hdf5-library)
-      * [For TREXIO developers: from the GitHub repo clone](#for-trexio-developers-from-the-github-repo-clone)
-      * [Using CMake instead of Autotools](#using-cmake-instead-of-autotools)
+  * [Installation using a package manager](#installation-using-a-package-manager)
+    * [Conda](#conda)
+    * [Spack](#spack)
+    * [Guix](#guix)
+    * [Debian/Ubuntu](#debianubuntu)
+  * [Installation from source](#installation-from-source)
+    * [Minimal requirements (for users):](#minimal-requirements-for-users)
+    * [Recommended: Installation from the release tarball](#recommended-installation-from-the-release-tarball)
+    * [Compilation without the HDF5 library](#compilation-without-the-hdf5-library)
+    * [For TREXIO developers: from the GitHub repo clone](#for-trexio-developers-from-the-github-repo-clone)
+    * [Using CMake instead of Autotools](#using-cmake-instead-of-autotools)
 * [Using TREXIO](#using-trexio)
-   * [Naming convention](#naming-convention)
-   * [Tutorial](#tutorial)
-   * [Documentation](#documentation)
-   * [Linking to your program](#linking-to-your-program)
-   * [Distributing TREXIO with your code](#distributing-trexio-with-your-code)
+  * [Naming convention](#naming-convention)
+  * [Tutorial](#tutorial)
+  * [Documentation](#documentation)
+  * [Linking to your program](#linking-to-your-program)
+  * [Distributing TREXIO with your code](#distributing-trexio-with-your-code)
 * [APIs for other languages](#apis-for-other-languages)
-   * [Python](#python)
-   * [Rust](#rust)
-   * [OCaml](#ocaml)
+  * [Python](#python)
+  * [Rust](#rust)
+  * [OCaml](#ocaml)
 * [Citation](#citation)
-   * [Miscellaneous](#miscellaneous)
+  * [Miscellaneous](#miscellaneous)
 
 
 ## Installation
@@ -110,7 +127,7 @@ sudo apt-get update && sudo apt-get install libtrexio-dev
 3. `cd trexio-<version>`
 4. `./configure`
 5. ```make -j 4 ```
-6. ```make -j 4 check```
+6. ```make -j $(nproc) check```
 7. `sudo make install`
 
 In environments where `sudo` access is unavailable, a common workaround for
@@ -155,7 +172,7 @@ Additional requirements:
 3. `./autogen.sh`
 4. `./configure`
 5. ```make -j 4```
-6. ```make -j 4 check```
+6. ```make -j $(nproc) check```
 7. `sudo make install`
 
 #### Using CMake instead of Autotools
@@ -166,7 +183,7 @@ The aforementioned instructions rely on [Autotools](https://www.gnu.org/software
 1. `cmake -S. -Bbuild`
 2. `cd build`
 3. ```make -j 4```
-4. ```ctest -j 4```
+4. ```ctest -j $(nproc)```
 5. `sudo make install`
 
 **Note**: on systems with no `sudo` access, one can add `-DCMAKE_INSTALL_PREFIX=build` as an argument to the `cmake` command so that `make install/uninstall` can be run without `sudo` privileges.

--- a/README.md
+++ b/README.md
@@ -15,21 +15,22 @@ which enables fast read and write operations. It is compatible with a variety
 of platforms and has interfaces for the Fortran, Python, OCaml and Rust
 programming languages.
 
-Below is the list of codes that adopted TREXIO for reading and/or writing single- and/or multi-reference wave functions:
+Below is the list of codes that adopted TREXIO for reading and/or writing 
+single- and/or multi-reference wave functions and the corresponding integrals:
 
-| Software                                                                       | Single-reference | Multi-reference |
-| ------------------------------------------------------------------------------ | ---------------- | --------------- |
-| [Quantum Package](https://github.com/QuantumPackage/qp2)                       | Write/Read       | Write/Read      |
-| [FHI-aims](https://fhi-aims.org/)                                              | Write/Read       | ??              |
-| [PySCF](https://github.com/pyscf/pyscf)                                        | Write/Read       | Write/Read      |
-| [CP2K](https://github.com/cp2k/cp2k)                                           | Write            | ---             |
-| [CHAMP](https://github.com/filippi-claudia/champ)                              | Read             | Read            |
-| [GammCor](https://github.com/pernalk/GAMMCOR)                                  | Read             | Read            |
-| [TurboRVB](https://github.com/sissaschool/turborvb)                            | Read             | ---             |
-| [ipie](https://github.com/JoonhoLee-Group/ipie)                                | Read             | ??              |
-| [Spicy](https://gitlab.com/theoretical-chemistry-jena/quantum-chemistry/Spicy) | Read             | ---             |
-| [QMC=Chem](https://github.com/TREX-CoE/qmcchem2)                               | Read             | Read            |
-| [QMCkl](https://github.com/TREX-CoE/qmckl)                                     | Read             | ---             |
+| Software                                                                       | Single-reference       | Multi-reference |
+| ------------------------------------------------------------------------------ | ---------------------- | --------------- |
+| [Quantum Package](https://github.com/QuantumPackage/qp2)                       | Write/Read + Integrals | Write/Read      |
+| [PySCF](https://github.com/pyscf/pyscf)                                        | Write/Read + Integrals | Write/Read      |
+| [FHI-aims](https://fhi-aims.org/)                                              | Write + Integrals      | ---             |
+| [CP2K](https://github.com/cp2k/cp2k)                                           | Write                  | ---             |
+| [CHAMP](https://github.com/filippi-claudia/champ)                              | Read                   | Read            |
+| [GammCor](https://github.com/pernalk/GAMMCOR)                                  | Read + Integrals       | Read            |
+| [ipie](https://github.com/JoonhoLee-Group/ipie)                                | Read + Integrals       | Read            |
+| [TurboRVB](https://github.com/sissaschool/turborvb)                            | Read                   | ---             |
+| [Spicy](https://gitlab.com/theoretical-chemistry-jena/quantum-chemistry/Spicy) | Read                   | ---             |
+| [QMC=Chem](https://github.com/TREX-CoE/qmcchem2)                               | Read                   | ---             |
+| [QMCkl](https://github.com/TREX-CoE/qmckl)                                     | Read                   | ---             |
 
 
 * [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ of platforms and has interfaces for the Fortran, Python, OCaml and Rust
 programming languages.
 
 Below is the list of codes that adopted TREXIO for reading and/or writing 
-single- and/or multi-reference wave functions and the corresponding integrals:
+single- and/or multi-reference wave functions:
 
-| Software                                                                       | Single-reference       | Multi-reference |
-| ------------------------------------------------------------------------------ | ---------------------- | --------------- |
-| [Quantum Package](https://github.com/QuantumPackage/qp2)                       | Write/Read + Integrals | Write/Read      |
-| [PySCF](https://github.com/pyscf/pyscf)                                        | Write/Read + Integrals | Write/Read      |
-| [FHI-aims](https://fhi-aims.org/)                                              | Write + Integrals      | ---             |
-| [CP2K](https://github.com/cp2k/cp2k)                                           | Write                  | ---             |
-| [CHAMP](https://github.com/filippi-claudia/champ)                              | Read                   | Read            |
-| [GammCor](https://github.com/pernalk/GAMMCOR)                                  | Read + Integrals       | Read            |
-| [ipie](https://github.com/JoonhoLee-Group/ipie)                                | Read + Integrals       | Read            |
-| [TurboRVB](https://github.com/sissaschool/turborvb)                            | Read                   | ---             |
-| [Spicy](https://gitlab.com/theoretical-chemistry-jena/quantum-chemistry/Spicy) | Read                   | ---             |
-| [QMC=Chem](https://github.com/TREX-CoE/qmcchem2)                               | Read                   | ---             |
-| [QMCkl](https://github.com/TREX-CoE/qmckl)                                     | Read                   | ---             |
+| Software                                                                       | Single-reference | Multi-reference |
+| ------------------------------------------------------------------------------ | ---------------- | --------------- |
+| [Quantum Package](https://github.com/QuantumPackage/qp2)                       | Write/Read       | Write/Read      |
+| [PySCF](https://github.com/pyscf/pyscf)                                        | Write/Read       | Write/Read      |
+| [FHI-aims](https://fhi-aims.org/)                                              | Write            | ---             |
+| [CP2K](https://github.com/cp2k/cp2k)                                           | Write            | ---             |
+| [CHAMP](https://github.com/filippi-claudia/champ)                              | Read             | Read            |
+| [GammCor](https://github.com/pernalk/GAMMCOR)                                  | Read             | Read            |
+| [ipie](https://github.com/JoonhoLee-Group/ipie)                                | Read             | Read            |
+| [TurboRVB](https://github.com/sissaschool/turborvb)                            | Read             | ---             |
+| [Spicy](https://gitlab.com/theoretical-chemistry-jena/quantum-chemistry/Spicy) | Read             | ---             |
+| [QMC=Chem](https://github.com/TREX-CoE/qmcchem2)                               | Read             | ---             |
+| [QMCkl](https://github.com/TREX-CoE/qmckl)                                     | Read             | ---             |
 
 
 * [Installation](#installation)


### PR DESCRIPTION
I added a table with the codes that adopted TREXIO in one way or another. 
@scemama could you please check if I did not forget anything? Especially the `ipie` and `FHI-aims` sections (see `??` signs). I suppose there is no multi-reference I/O in FHI-aims and QMCkl?
@kousuke-nakano TurboRVB does not read multi-reference wave functions via TREXIO, right?
@stefabat Does CP2K support now both writing and reading (export and import) of the TREXIO (Hartree-Fock) wave functions?