### PR TITLE
Add Madelung correction

### DIFF
--- a/trex.org
+++ b/trex.org
@@ -130,12 +130,13 @@
 
 
    #+NAME: pbc
-  | Variable         | Type    | Row-major Dimensions | Column-major Dimensions | Description             |
-  |------------------+---------+----------------------+-------------------------+-------------------------|
-  | ~periodic~       | ~int~   |                      |                         | ~1~: true or ~0~: false |
-  | ~k_point_num~    | ~dim~   |                      |                         | Number of $k$-points    |
-  | ~k_point~        | ~float~ | ~[3]~                | ~(3)~                   | $k$-point sampling      |
-  | ~k_point_weight~ | ~float~ | ~[pbc.k_point_num]~  | ~(pbc.k_point_num)~     | $k$-point weight        |
+  | Variable         | Type    | Row-major Dimensions | Column-major Dimensions | Description                                          |
+  |------------------+---------+----------------------+-------------------------+------------------------------------------------------|
+  | ~periodic~       | ~int~   |                      |                         | ~1~: true or ~0~: false                              |
+  | ~k_point_num~    | ~dim~   |                      |                         | Number of $k$-points                                 |
+  | ~k_point~        | ~float~ | ~[3]~                | ~(3)~                   | $k$-point sampling                                   |
+  | ~k_point_weight~ | ~float~ | ~[pbc.k_point_num]~  | ~(pbc.k_point_num)~     | $k$-point weight                                     |
+  | ~madelung~       | ~float~ |                      |                         | Madelung correction of the Ewald probe charge method |
 
    #+CALL: json(data=pbc, title="pbc")
 
@@ -147,6 +148,7 @@
          ,    "k_point_num" : [ "dim"  , []                    ]
          ,        "k_point" : [ "float", [ "3" ]               ]
          , "k_point_weight" : [ "float", [ "pbc.k_point_num" ] ]
+         ,       "madelung" : [ "float", []                    ]
        } ,
    #+end_src
    :end:


### PR DESCRIPTION
In periodic calculations, the Hartree-Fock exchange doesn't compensate well the periodic Coulomb part, and the Madelung constant has to be used to get the correct energy. 