### PR TITLE
Fix long lines in Fortran

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -266,10 +266,11 @@ GENERATOR_FILES = $(srcdir)/tools/generator.py \
 $(SOURCES): $(trexio_h)
 src/trexio.c: $(trexio_h)
 
-$(trexio_h): $(ORG_FILES) $(GENERATOR_FILES)
-	cd $(srcdir)/tools && ./build_trexio.sh
+trex.json: trex.org
+	cd $(srcdir)/tools && ./build_json.sh
 
-trex.json: $(trexio_h)
+$(trexio_h): $(ORG_FILES) $(GENERATOR_FILES) trex.json
+	cd $(srcdir)/tools && ./build_trexio.sh
 
 $(htmlizer): $(ORG_FILES) $(srcdir)/src/README.org
 	touch $(htmlizer)

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@
 # =============== SETTINGS =============== #
 
 ACLOCAL_AMFLAGS = -I m4
-CLEANFILES = trexio.mod
+CLEANFILES = trexio.mod tests/trexio_f.f90
 BUILT_SOURCES = trex.json
 if HAVE_FORTRAN
 BUILT_SOURCES += trexio.mod

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -4584,34 +4584,38 @@ end interface
      #+end_src
 
   #+begin_src f90 :tangle helper_read_dset_str_front_fortran.fh_90
-   integer(trexio_exit_code) function &
-        trexio_read_$group_dset$ &
-        (trex_file, dset, max_str_len)
-     implicit none
-     integer(trexio_t), intent(in), value :: trex_file
-     integer(c_int32_t), intent(in), value :: max_str_len
-     character(len=*), intent(inout) :: dset(*)
+integer(trexio_exit_code) function &
+     trexio_read_$group_dset$ &
+     (trex_file, dset, max_str_len)
+  implicit none
+  integer(trexio_t), intent(in), value :: trex_file
+  integer(c_int32_t), intent(in), value :: max_str_len
+  character(len=*), intent(inout) :: dset(*)
 
-     character, allocatable :: str_compiled(:)
-     integer(c_int64_t) :: $group_dset_dim$
-     integer(trexio_exit_code) :: rc
+  character, allocatable :: str_compiled(:)
+  integer(c_int64_t) :: $group_dset_dim$
+  integer(trexio_exit_code) :: rc
 
-     rc = trexio_read_$group_dset_dim$_64(trex_file, $group_dset_dim$)
-     if (rc /= TREXIO_SUCCESS) trexio_read_$group_dset$ = rc
+  rc = trexio_read_$group_dset_dim$_64 &
+       (trex_file, $group_dset_dim$)
+  if (rc /= TREXIO_SUCCESS) then
+     trexio_read_$group_dset$ = rc
+  endif
 
-     allocate(str_compiled($group_dset_dim$*(max_str_len+1)+1))
+  allocate(str_compiled($group_dset_dim$*(max_str_len+1)+1))
 
-     rc = trexio_read_$group_dset$_low(trex_file, str_compiled, max_str_len)
-     if (rc /= TREXIO_SUCCESS) then
-       deallocate(str_compiled)
-       trexio_read_$group_dset$ = rc
-     else
-       call trexio_str2strarray(str_compiled, $group_dset_dim$, max_str_len, dset)
-       deallocate(str_compiled)
-       trexio_read_$group_dset$ = TREXIO_SUCCESS
-     endif
+  rc = trexio_read_$group_dset$_low(trex_file, str_compiled, max_str_len)
+  if (rc /= TREXIO_SUCCESS) then
+    deallocate(str_compiled)
+    trexio_read_$group_dset$ = rc
+  else
+    call trexio_str2strarray(str_compiled, &
+         $group_dset_dim$, max_str_len, dset)
+    deallocate(str_compiled)
+    trexio_read_$group_dset$ = TREXIO_SUCCESS
+  endif
 
-   end function trexio_read_$group_dset$
+end function trexio_read_$group_dset$
   #+end_src
 
   #+begin_src f90 :tangle helper_write_dset_str_front_fortran.fh_90
@@ -4627,12 +4631,15 @@ end interface
      integer(c_int64_t) :: $group_dset_dim$
      integer(trexio_exit_code) :: rc
 
-     rc = trexio_read_$group_dset_dim$_64(trex_file, $group_dset_dim$)
+     rc = trexio_read_$group_dset_dim$_64 &
+          (trex_file, $group_dset_dim$)
      if (rc /= TREXIO_SUCCESS) then
        trexio_write_$group_dset$ = rc
      else
        call trexio_strarray2str(dset, $group_dset_dim$, str_compiled)
-       trexio_write_$group_dset$ = trexio_write_$group_dset$_low(trex_file, str_compiled, max_str_len)
+       trexio_write_$group_dset$ = &
+            trexio_write_$group_dset$_low &
+            (trex_file, str_compiled, max_str_len)
      endif
 
    end function trexio_write_$group_dset$
@@ -5324,31 +5331,35 @@ end interface
      #+end_src
 
   #+begin_src f90 :tangle helper_read_attr_str_front_fortran.fh_90
-   integer(trexio_exit_code) function &
-        trexio_read_$group_str$ &
-        (trex_file, str, max_str_len)
-     implicit none
-     integer(trexio_t), intent(in), value  :: trex_file
-     integer(c_int32_t), intent(in), value :: max_str_len
-     character, intent(out) :: str(*)
+integer(trexio_exit_code) function &
+     trexio_read_$group_str$ &
+     (trex_file, str, max_str_len)
+  implicit none
+  integer(trexio_t), intent(in), value  :: trex_file
+  integer(c_int32_t), intent(in), value :: max_str_len
+  character, intent(out) :: str(*)
 
-     trexio_read_$group_str$ = trexio_read_$group_str$_c(trex_file, str, max_str_len)
+  trexio_read_$group_str$ = &
+   trexio_read_$group_str$_c &
+   (trex_file, str, max_str_len)
 
-   end function trexio_read_$group_str$
+end function trexio_read_$group_str$
   #+end_src
 
   #+begin_src f90 :tangle helper_write_attr_str_front_fortran.fh_90
-   integer(trexio_exit_code) function &
-        trexio_write_$group_str$ &
-        (trex_file, str, max_str_len)
-     implicit none
-     integer(trexio_t), intent(in), value  :: trex_file
-     integer(c_int32_t), intent(in), value :: max_str_len
-     character(len=*), intent(in) :: str
+integer(trexio_exit_code) function &
+     trexio_write_$group_str$ &
+     (trex_file, str, max_str_len)
+  implicit none
+  integer(trexio_t), intent(in), value  :: trex_file
+  integer(c_int32_t), intent(in), value :: max_str_len
+  character(len=*), intent(in) :: str
 
-     trexio_write_$group_str$ = trexio_write_$group_str$_c(trex_file, trim(str) // c_null_char, max_str_len)
+  trexio_write_$group_str$ = &
+   trexio_write_$group_str$_c &
+   (trex_file, trim(str) // c_null_char, max_str_len)
 
-   end function trexio_write_$group_str$
+end function trexio_write_$group_str$
   #+end_src
 
 *** Python templates for front end
@@ -6906,10 +6917,10 @@ def evaluate_nao_radial_all(nucleus_index, nucleus_coords, grid_start,
 
   #+begin_src f90 :tangle helper_fortran.f90
 contains
-   integer function trexio_info ()
-     implicit none
-     trexio_info = trexio_info_c()
-   end function trexio_info
+integer function trexio_info ()
+  implicit none
+  trexio_info = trexio_info_c()
+end function trexio_info
   #+end_src
 
   This function adds the string length as an extra argument to help the C code
@@ -6930,24 +6941,24 @@ end subroutine trexio_string_of_error
   Note, that Fortran interface calls the main ~TREXIO~ API, which is written in C.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   integer(trexio_t) function trexio_open (filename, mode, back_end, rc_open)
-     implicit none
-     character(len=*), intent(in)                    :: filename
-     character, intent(in), value                    :: mode
-     integer(trexio_back_end_t), intent(in), value   :: back_end
-     integer(trexio_exit_code), intent(out)          :: rc_open
-     integer(trexio_exit_code) :: rc
+integer(trexio_t) function trexio_open (filename, mode, back_end, rc_open)
+  implicit none
+  character(len=*), intent(in)                    :: filename
+  character, intent(in), value                    :: mode
+  integer(trexio_back_end_t), intent(in), value   :: back_end
+  integer(trexio_exit_code), intent(out)          :: rc_open
+  integer(trexio_exit_code) :: rc
 
-     trexio_open = trexio_open_c(trim(filename) // c_null_char, mode, back_end, rc_open)
-     if (trexio_open == 0_8 .or. rc_open /= TREXIO_SUCCESS) then
-       return
-     endif
-     rc = trexio_set_one_based(trexio_open)
-     if (rc /= TREXIO_SUCCESS) then
-        rc = trexio_close(trexio_open)
-        trexio_open = 0_8
-     endif
-   end function trexio_open
+  trexio_open = trexio_open_c(trim(filename) // c_null_char, mode, back_end, rc_open)
+  if (trexio_open == 0_8 .or. rc_open /= TREXIO_SUCCESS) then
+     return
+  endif
+  rc = trexio_set_one_based(trexio_open)
+  if (rc /= TREXIO_SUCCESS) then
+     rc = trexio_close(trexio_open)
+     trexio_open = 0_8
+  endif
+end function trexio_open
   #+end_src
 
   The function below adapts the original C-based ~trexio_inquire~ for Fortran.
@@ -6955,98 +6966,102 @@ end subroutine trexio_string_of_error
   Note, that Fortran interface calls the main ~TREXIO~ API, which is written in C.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   integer(trexio_exit_code) function trexio_inquire (filename)
-     implicit none
-     character(len=*), intent(in)        :: filename
+integer(trexio_exit_code) function trexio_inquire (filename)
+  implicit none
+  character(len=*), intent(in)        :: filename
 
-     trexio_inquire = trexio_inquire_c(trim(filename) // c_null_char)
-   end function trexio_inquire
+  trexio_inquire = trexio_inquire_c(trim(filename) // c_null_char)
+end function trexio_inquire
   #+end_src
 
   Similarly, the following function adapts ~trexio_cp~.
 
   #+begin_src f90 :tangle helper_fortran.f90
-  integer(trexio_exit_code) function trexio_cp (source, destination)
-    implicit none
-    character(len=*), intent(in)           :: source
-    character(len=*), intent(in)           :: destination
+integer(trexio_exit_code) function trexio_cp (source, destination)
+  implicit none
+  character(len=*), intent(in)           :: source
+  character(len=*), intent(in)           :: destination
 
-    trexio_cp = trexio_cp_c(trim(source) // c_null_char, trim(destination) // c_null_char)
-  end function trexio_cp
+  trexio_cp = trexio_cp_c(trim(source) // c_null_char, trim(destination) // c_null_char)
+end function trexio_cp
    #+end_src
 
   The subroutines below wrap the ~to_orbital_list~ functions to shift the MO indices
   by 1 since in Fortran arrays are 1-based and C/Python they are 0-based.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   integer(trexio_exit_code) function &
-        trexio_to_bitfield_list &
-        (list, occupied_num, det_list, N_int)
-     implicit none
+integer(trexio_exit_code) function &
+     trexio_to_bitfield_list &
+     (list, occupied_num, det_list, N_int)
+  implicit none
 
-     integer(c_int32_t), intent(in)        :: list(*)
-     integer(c_int32_t), intent(in), value :: occupied_num
-     integer(c_int64_t), intent(out)       :: det_list(*)
-     integer(c_int32_t), intent(in), value :: N_int
-     integer(c_int32_t)                    :: list_0based(occupied_num)
+  integer(c_int32_t), intent(in)        :: list(*)
+  integer(c_int32_t), intent(in), value :: occupied_num
+  integer(c_int64_t), intent(out)       :: det_list(*)
+  integer(c_int32_t), intent(in), value :: N_int
+  integer(c_int32_t)                    :: list_0based(occupied_num)
 
-     integer :: i
-     do i = 1,occupied_num
-       list_0based(i) = list(i) - 1
-     enddo
+  integer :: i
+  do i = 1,occupied_num
+    list_0based(i) = list(i) - 1
+  enddo
 
-     trexio_to_bitfield_list = trexio_to_bitfield_list_c(list_0based, occupied_num, det_list, N_int)
-     if (trexio_to_bitfield_list /= TREXIO_SUCCESS) then
-       return
-     endif
+  trexio_to_bitfield_list = trexio_to_bitfield_list_c(list_0based, occupied_num, det_list, N_int)
+  if (trexio_to_bitfield_list /= TREXIO_SUCCESS) then
+    return
+  endif
 
-   end function trexio_to_bitfield_list
-
-
-   integer(trexio_exit_code) function trexio_to_orbital_list(N_int, d1, list, occupied_num)
-     implicit none
-
-     integer(c_int32_t), intent(in), value :: N_int
-     integer(c_int64_t), intent(in)        :: d1(*)
-     integer(c_int32_t), intent(out)       :: list(*)
-     integer(c_int32_t), intent(out)       :: occupied_num
-
-     integer :: i
-
-     trexio_to_orbital_list = trexio_to_orbital_list_c(N_int, d1, list, occupied_num)
-     if (trexio_to_orbital_list /= TREXIO_SUCCESS) then
-       return
-     endif
-
-     do i = 1,occupied_num
-       list(i) = list(i) + 1
-     enddo
-   end function trexio_to_orbital_list
+end function trexio_to_bitfield_list
 
 
-   integer(trexio_exit_code) function trexio_to_orbital_list_up_dn(N_int, d1, list_up, list_dn, occ_num_up, occ_num_dn)
-     implicit none
-     integer(c_int32_t), intent(in), value :: N_int
-     integer(c_int64_t), intent(in)        :: d1(*)
-     integer(c_int32_t), intent(out)       :: list_up(*)
-     integer(c_int32_t), intent(out)       :: list_dn(*)
-     integer(c_int32_t), intent(out)       :: occ_num_up
-     integer(c_int32_t), intent(out)       :: occ_num_dn
+integer(trexio_exit_code) function trexio_to_orbital_list(N_int, d1, list, occupied_num)
+  implicit none
 
-     integer :: i
+  integer(c_int32_t), intent(in), value :: N_int
+  integer(c_int64_t), intent(in)        :: d1(*)
+  integer(c_int32_t), intent(out)       :: list(*)
+  integer(c_int32_t), intent(out)       :: occupied_num
 
-     trexio_to_orbital_list_up_dn = trexio_to_orbital_list_up_dn_c(N_int, d1, list_up, list_dn, occ_num_up, occ_num_dn)
-     if (trexio_to_orbital_list_up_dn /= TREXIO_SUCCESS) then
-       return
-     endif
+  integer :: i
 
-     do i = 1,occ_num_up
-       list_up(i) = list_up(i) + 1
-     enddo
-     do i = 1,occ_num_dn
-       list_dn(i) = list_dn(i) + 1
-     enddo
-   end function trexio_to_orbital_list_up_dn
+  trexio_to_orbital_list = trexio_to_orbital_list_c(N_int, d1, list, occupied_num)
+  if (trexio_to_orbital_list /= TREXIO_SUCCESS) then
+    return
+  endif
+
+  do i = 1,occupied_num
+    list(i) = list(i) + 1
+  enddo
+end function trexio_to_orbital_list
+
+
+integer(trexio_exit_code) function &
+     trexio_to_orbital_list_up_dn &
+     (N_int, d1, list_up, list_dn, occ_num_up, occ_num_dn)
+  implicit none
+  integer(c_int32_t), intent(in), value :: N_int
+  integer(c_int64_t), intent(in)        :: d1(*)
+  integer(c_int32_t), intent(out)       :: list_up(*)
+  integer(c_int32_t), intent(out)       :: list_dn(*)
+  integer(c_int32_t), intent(out)       :: occ_num_up
+  integer(c_int32_t), intent(out)       :: occ_num_dn
+
+  integer :: i
+
+  trexio_to_orbital_list_up_dn = &
+       trexio_to_orbital_list_up_dn_c &
+       (N_int, d1, list_up, list_dn, occ_num_up, occ_num_dn)
+  if (trexio_to_orbital_list_up_dn /= TREXIO_SUCCESS) then
+    return
+  endif
+
+  do i = 1,occ_num_up
+    list_up(i) = list_up(i) + 1
+  enddo
+  do i = 1,occ_num_dn
+    list_dn(i) = list_dn(i) + 1
+  enddo
+end function trexio_to_orbital_list_up_dn
   #+end_src
 
   The subroutine below transforms an array of Fortran strings into one big string using ~TREXIO_DELIM~ symbol
@@ -7054,55 +7069,55 @@ end subroutine trexio_string_of_error
   C API. This is needed due to the fact that strings in C are terminated by ~NULL~ character ~\0~.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   subroutine trexio_strarray2str(str_array, max_num_str, str_res)
-     implicit none
+subroutine trexio_strarray2str(str_array, max_num_str, str_res)
+  implicit none
 
-     integer(c_int64_t), intent(in), value   :: max_num_str  ! number of elements in string array
-     character(len=*), intent(in)  :: str_array(*)
-     character(len=:), allocatable, intent(out) :: str_res
-     integer(c_int64_t) :: i
+  integer(c_int64_t), intent(in), value   :: max_num_str  ! number of elements in string array
+  character(len=*), intent(in)  :: str_array(*)
+  character(len=:), allocatable, intent(out) :: str_res
+  integer(c_int64_t) :: i
 
-     str_res = ''
-     do i = 1, max_num_str
-       str_res = str_res // trim(str_array(i)) // TREXIO_DELIM
-     enddo
-     str_res = str_res // c_null_char
+  str_res = ''
+  do i = 1, max_num_str
+     str_res = str_res // trim(str_array(i)) // TREXIO_DELIM
+  enddo
+  str_res = str_res // c_null_char
 
-   end subroutine trexio_strarray2str
+end subroutine trexio_strarray2str
      #+end_src
 
   The subroutine below does the reverse tranformation from one big string with delimeters into an array of Fortran strings.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   subroutine trexio_str2strarray(str_flat, max_num_str, max_len_str, str_array)
-     implicit none
+subroutine trexio_str2strarray(str_flat, max_num_str, max_len_str, str_array)
+  implicit none
 
-     integer(c_int64_t), intent(in), value   :: max_num_str  ! number of elements in strign array
-     integer, intent(in), value              :: max_len_str  ! maximum length of a string in an array
-     character(kind=c_char), intent(in)      :: str_flat(*)
-     character(len=*), intent(inout)         :: str_array(*)
+  integer(c_int64_t), intent(in), value   :: max_num_str  ! number of elements in strign array
+  integer, intent(in), value              :: max_len_str  ! maximum length of a string in an array
+  character(kind=c_char), intent(in)      :: str_flat(*)
+  character(len=*), intent(inout)         :: str_array(*)
 
-     character(len=max_len_str)  :: tmp_str
-     integer(c_int64_t) :: i, j, k, ind, len_flat
+  character(len=max_len_str)  :: tmp_str
+  integer(c_int64_t) :: i, j, k, ind, len_flat
 
-     len_flat = (max_len_str+1)*max_num_str + 1
+  len_flat = (max_len_str+1)*max_num_str + 1
 
-     ind=1
-     do i=1,max_num_str
-       k = 1
-       tmp_str=''
-       do j=ind,len_flat
-         if (str_flat(j) == TREXIO_DELIM) then
+  ind=1
+  do i=1,max_num_str
+     k = 1
+     tmp_str=''
+     do j=ind,len_flat
+        if (str_flat(j) == TREXIO_DELIM) then
            ind=j+1
            exit
-         endif
-         tmp_str(k:k) = str_flat(j)
-         k = k + 1
-       enddo
-       str_array(i)=tmp_str
+        endif
+        tmp_str(k:k) = str_flat(j)
+        k = k + 1
      enddo
+     str_array(i)=tmp_str
+  enddo
 
-   end subroutine trexio_str2strarray
+end subroutine trexio_str2strarray
      #+end_src
 
 
@@ -7111,24 +7126,24 @@ end subroutine trexio_string_of_error
   two code are identical, i.e. if the ~assert~ statement pass.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   subroutine trexio_assert(trexio_rc, check_rc, success_message)
-     implicit none
+subroutine trexio_assert(trexio_rc, check_rc, success_message)
+  implicit none
 
-     integer, intent(in), value :: trexio_rc
-     integer, intent(in), value :: check_rc
-     character(len=*), intent(in), optional  :: success_message
+  integer, intent(in), value :: trexio_rc
+  integer, intent(in), value :: check_rc
+  character(len=*), intent(in), optional  :: success_message
 
-     character*(128) :: str
+  character*(128) :: str
 
-     if (trexio_rc == check_rc) then
-       if (present(success_message)) write(*,*) success_message
-     else
-       call trexio_string_of_error(trexio_rc, str)
-       print *, trim(str)
-       stop 1
-     endif
+  if (trexio_rc == check_rc) then
+     if (present(success_message)) write(*,*) success_message
+  else
+     call trexio_string_of_error(trexio_rc, str)
+     print *, trim(str)
+     stop 1
+  endif
 
-   end subroutine trexio_assert
+end subroutine trexio_assert
      #+end_src
 
 * File suffixes                                                     :noexport:

--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -2391,7 +2391,9 @@ trexio_has_$group$ (trexio_t* const file)
 
      #+begin_src f90 :tangle has_group_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_$group$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_$group$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
    end function trexio_has_$group$
@@ -2677,7 +2679,9 @@ trexio_has_$group_num$ (trexio_t* const file)
 
      #+begin_src f90 :tangle write_attr_num_64_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_num$_64 (trex_file, num) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_num$_64 &
+        (trex_file, num) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_num_f_dtype_double$, intent(in), value :: num
@@ -2687,7 +2691,9 @@ end interface
 
      #+begin_src f90 :tangle read_attr_num_64_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_num$_64 (trex_file, num) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_num$_64 &
+        (trex_file, num) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_num_f_dtype_double$, intent(out) :: num
@@ -2697,7 +2703,9 @@ end interface
 
      #+begin_src f90 :tangle write_attr_num_32_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_num$_32 (trex_file, num) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_num$_32 &
+        (trex_file, num) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_num_f_dtype_single$, intent(in), value :: num
@@ -2707,7 +2715,9 @@ end interface
 
      #+begin_src f90 :tangle read_attr_num_32_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_num$_32 (trex_file, num) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_num$_32 &
+        (trex_file, num) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_num_f_dtype_single$, intent(out) :: num
@@ -2717,7 +2727,9 @@ end interface
 
      #+begin_src f90 :tangle write_attr_num_def_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_num$ (trex_file, num) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_num$ &
+        (trex_file, num) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_num_f_dtype_default$, intent(in), value :: num
@@ -2727,7 +2739,9 @@ end interface
 
      #+begin_src f90 :tangle read_attr_num_def_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_num$ (trex_file, num) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_num$ &
+        (trex_file, num) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_num_f_dtype_default$, intent(out) :: num
@@ -2737,7 +2751,9 @@ end interface
 
      #+begin_src f90 :tangle has_attr_num_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_$group_num$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_$group_num$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
    end function trexio_has_$group_num$
@@ -3332,7 +3348,9 @@ trexio_has_$group_dset$ (trexio_t* const file)
 
      #+begin_src f90 :tangle write_dset_data_64_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_dset$_64 (trex_file, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_dset$_64 &
+        (trex_file, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_dset_f_dtype_double$, intent(in) :: dset$group_dset_f_dims$
@@ -3342,7 +3360,9 @@ end interface
 
      #+begin_src f90 :tangle read_dset_data_64_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$_64 (trex_file, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$_64 &
+        (trex_file, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_dset_f_dtype_double$, intent(out) :: dset$group_dset_f_dims$
@@ -3352,7 +3372,9 @@ end interface
 
      #+begin_src f90 :tangle write_dset_data_32_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_dset$_32 (trex_file, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_dset$_32 &
+        (trex_file, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_dset_f_dtype_single$, intent(in) :: dset$group_dset_f_dims$
@@ -3362,7 +3384,9 @@ end interface
 
      #+begin_src f90 :tangle read_dset_data_32_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$_32 (trex_file, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$_32 &
+        (trex_file, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_dset_f_dtype_single$, intent(out) :: dset$group_dset_f_dims$
@@ -3372,7 +3396,9 @@ end interface
 
      #+begin_src f90 :tangle write_dset_data_def_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_dset$ (trex_file, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_dset$ &
+        (trex_file, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_dset_f_dtype_default$, intent(in) :: dset$group_dset_f_dims$
@@ -3382,7 +3408,9 @@ end interface
 
      #+begin_src f90 :tangle read_dset_data_def_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$ (trex_file, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$ &
+        (trex_file, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      $group_dset_f_dtype_default$, intent(out) :: dset$group_dset_f_dims$
@@ -3392,7 +3420,9 @@ end interface
 
      #+begin_src f90 :tangle has_dset_data_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_$group_dset$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_$group_dset$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
    end function trexio_has_$group_dset$
@@ -3959,9 +3989,11 @@ trexio_has_$group_dset$ (trexio_t* const file)
 
      #+begin_src f90 :tangle write_dset_sparse_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_dset$ (trex_file, &
-                                               offset_file, buffer_size, &
-                                               index_sparse, value_sparse) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_dset$&
+        (trex_file, &
+        offset_file, buffer_size, &
+        index_sparse, value_sparse) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -3972,10 +4004,12 @@ interface
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_write_safe_$group_dset$ (trex_file, &
-                                                    offset_file, buffer_size, &
-                                                    index_sparse, index_size, &
-                                                    value_sparse, value_size) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_safe_$group_dset$ &
+        (trex_file, &
+        offset_file, buffer_size, &
+        index_sparse, index_size, &
+        value_sparse, value_size) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -3990,9 +4024,11 @@ end interface
 
      #+begin_src f90 :tangle read_dset_sparse_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$ (trex_file, &
-                                              offset_file, buffer_size, &
-                                              index_sparse, value_sparse) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$ &
+        (trex_file, &
+        offset_file, buffer_size, &
+        index_sparse, value_sparse) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -4003,10 +4039,12 @@ interface
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_read_safe_$group_dset$ (trex_file, &
-                                                   offset_file, buffer_size, &
-                                                   index_sparse, index_size, &
-                                                   value_sparse, value_size) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_safe_$group_dset$ &
+        (trex_file, &
+        offset_file, buffer_size, &
+        index_sparse, index_size, &
+        value_sparse, value_size) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -4021,8 +4059,9 @@ end interface
 
      #+begin_src f90 :tangle read_dset_sparse_size_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$_size (trex_file, &
-                                                   size_max) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$_size &
+        (trex_file, size_max) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(out) :: size_max
@@ -4032,7 +4071,9 @@ end interface
 
      #+begin_src f90 :tangle has_dset_sparse_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_$group_dset$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_$group_dset$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
    end function trexio_has_$group_dset$
@@ -4507,7 +4548,9 @@ trexio_has_$group_dset$ (trexio_t* const file)
 
      #+begin_src f90 :tangle write_dset_str_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_dset$_low (trex_file, dset, max_str_len) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_dset$_low &
+        (trex_file, dset, max_str_len) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      character(kind=c_char), intent(in)    :: dset(*)
@@ -4518,7 +4561,9 @@ end interface
 
      #+begin_src f90 :tangle read_dset_str_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$_low (trex_file, dset, max_str_len) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$_low &
+        (trex_file, dset, max_str_len) bind(C)
      import
      integer(c_int64_t), intent(in), value  :: trex_file
      character(kind=c_char), intent(out)    :: dset(*)
@@ -4529,7 +4574,9 @@ end interface
 
      #+begin_src f90 :tangle has_dset_str_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_$group_dset$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_$group_dset$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
    end function trexio_has_$group_dset$
@@ -4537,7 +4584,9 @@ end interface
      #+end_src
 
   #+begin_src f90 :tangle helper_read_dset_str_front_fortran.fh_90
-   integer(trexio_exit_code) function trexio_read_$group_dset$ (trex_file, dset, max_str_len)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$ &
+        (trex_file, dset, max_str_len)
      implicit none
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int32_t), intent(in), value :: max_str_len
@@ -4566,7 +4615,9 @@ end interface
   #+end_src
 
   #+begin_src f90 :tangle helper_write_dset_str_front_fortran.fh_90
-   integer(trexio_exit_code) function trexio_write_$group_dset$ (trex_file, dset, max_str_len)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_dset$ &
+        (trex_file, dset, max_str_len)
      implicit none
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int32_t), intent(in), value :: max_str_len
@@ -4887,8 +4938,9 @@ trexio_has_$group_dset$ (trexio_t* const file)
 
      #+begin_src f90 :tangle write_buffered_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_dset$(trex_file, &
-                                               offset_file, buffer_size, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_dset$ &
+        (trex_file, offset_file, buffer_size, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -4898,9 +4950,11 @@ interface
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_write_safe_$group_dset$ (trex_file, &
-                                                    offset_file, buffer_size, &
-                                                    dset, dset_size) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_safe_$group_dset$ &
+        (trex_file, &
+        offset_file, buffer_size, &
+        dset, dset_size) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -4913,9 +4967,11 @@ end interface
 
      #+begin_src f90 :tangle read_buffered_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_safe_$group_dset$ (trex_file, &
-                                                   offset_file, buffer_size, &
-                                                   dset, dset_size) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_safe_$group_dset$ &
+        (trex_file, &
+        offset_file, buffer_size, &
+        dset, dset_size) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -4926,8 +4982,9 @@ interface
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$(trex_file, &
-                                              offset_file, buffer_size, dset) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$ &
+        (trex_file, offset_file, buffer_size, dset) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -4937,8 +4994,9 @@ interface
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_read_$group_dset$_size (trex_file, &
-                                                   size_max) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_dset$_size &
+        (trex_file, size_max) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(out) :: size_max
@@ -4948,7 +5006,9 @@ end interface
 
      #+begin_src f90 :tangle has_buffered_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_$group_dset$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_$group_dset$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
    end function trexio_has_$group_dset$
@@ -5226,8 +5286,10 @@ trexio_has_$group_str$ (trexio_t* const file)
 
      #+begin_src f90 :tangle write_attr_str_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_$group_str$_c (trex_file, str, max_str_len) &
-           bind(C, name="trexio_write_$group_str$")
+   integer(trexio_exit_code) function &
+        trexio_write_$group_str$_c &
+        (trex_file, str, max_str_len) bind(C, &
+        name="trexio_write_$group_str$")
      import
      integer(trexio_t), intent(in), value  :: trex_file
      character(kind=c_char), intent(in)    :: str(*)
@@ -5238,8 +5300,10 @@ end interface
 
      #+begin_src f90 :tangle read_attr_str_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_$group_str$_c (trex_file, str, max_str_len) &
-           bind(C, name="trexio_read_$group_str$")
+   integer(trexio_exit_code) function &
+        trexio_read_$group_str$_c &
+        (trex_file, str, max_str_len) bind(C, &
+        name="trexio_read_$group_str$")
      import
      integer(trexio_t), intent(in), value  :: trex_file
      character(kind=c_char), intent(out)   :: str(*)
@@ -5250,7 +5314,9 @@ end interface
 
      #+begin_src f90 :tangle has_attr_str_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_$group_str$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_$group_str$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value  :: trex_file
    end function trexio_has_$group_str$
@@ -5258,7 +5324,9 @@ end interface
      #+end_src
 
   #+begin_src f90 :tangle helper_read_attr_str_front_fortran.fh_90
-   integer(trexio_exit_code) function trexio_read_$group_str$ (trex_file, str, max_str_len)
+   integer(trexio_exit_code) function &
+        trexio_read_$group_str$ &
+        (trex_file, str, max_str_len)
      implicit none
      integer(trexio_t), intent(in), value  :: trex_file
      integer(c_int32_t), intent(in), value :: max_str_len
@@ -5270,7 +5338,9 @@ end interface
   #+end_src
 
   #+begin_src f90 :tangle helper_write_attr_str_front_fortran.fh_90
-   integer(trexio_exit_code) function trexio_write_$group_str$ (trex_file, str, max_str_len)
+   integer(trexio_exit_code) function &
+        trexio_write_$group_str$ &
+        (trex_file, str, max_str_len)
      implicit none
      integer(trexio_t), intent(in), value  :: trex_file
      integer(c_int32_t), intent(in), value :: max_str_len
@@ -5403,7 +5473,9 @@ trexio_delete_$group$ (trexio_t* const file)
 
      #+begin_src f90 :tangle delete_group_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_delete_$group$ (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_delete_$group$ &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value  :: trex_file
    end function trexio_delete_$group$
@@ -5746,8 +5818,9 @@ trexio_has_determinant_list (trexio_t* const file)
 
      #+begin_src f90 :tangle write_determinant_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_write_determinant_list (trex_file, &
-                                               offset_file, buffer_size, list) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_determinant_list &
+        (trex_file, offset_file, buffer_size, list) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -5757,9 +5830,11 @@ interface
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_write_safe_determinant_list (trex_file, &
-                                                    offset_file, buffer_size, &
-                                                    list, list_size) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_write_safe_determinant_list &
+        (trex_file, &
+        offset_file, buffer_size, &
+        list, list_size) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -5772,8 +5847,9 @@ end interface
 
      #+begin_src f90 :tangle read_determinant_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_read_determinant_list(trex_file, &
-                                              offset_file, buffer_size, list) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_determinant_list &
+     (trex_file, offset_file, buffer_size, list) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -5783,9 +5859,11 @@ interface
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_read_safe_determinant_list (trex_file, &
-                                                   offset_file, buffer_size, &
-                                                   list, list_size) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_read_safe_determinant_list &
+        (trex_file, &
+        offset_file, buffer_size, &
+        list, list_size) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int64_t), intent(in), value :: offset_file
@@ -5798,14 +5876,18 @@ end interface
 
      #+begin_src f90 :tangle has_determinant_front_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_has_determinant_list (trex_file) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_has_determinant_list &
+        (trex_file) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
    end function trexio_has_determinant_list
 end interface
 
 interface
-   integer(trexio_exit_code) function trexio_get_int64_num (trex_file, num) bind(C)
+   integer(trexio_exit_code) function &
+        trexio_get_int64_num &
+        (trex_file, num) bind(C)
      import
      integer(trexio_t), intent(in), value :: trex_file
      integer(c_int32_t), intent(out) :: num
@@ -6509,8 +6591,10 @@ end interface
 
    #+begin_src f90 :tangle prefix_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_to_bitfield_list_c(list, occupied_num, det_list, N_int) &
-   bind(C, name="trexio_to_bitfield_list")
+   integer(trexio_exit_code) function &
+        trexio_to_bitfield_list_c &
+        (list, occupied_num, det_list, N_int) &
+        bind(C, name="trexio_to_bitfield_list")
      import
      integer(c_int32_t), intent(in)        :: list(*)
      integer(c_int32_t), intent(in), value :: occupied_num
@@ -6522,8 +6606,10 @@ end interface
 
    #+begin_src f90 :tangle prefix_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_to_orbital_list_c(N_int, d1, list, occupied_num) &
-   bind(C, name="trexio_to_orbital_list")
+   integer(trexio_exit_code) function &
+        trexio_to_orbital_list_c &
+        (N_int, d1, list, occupied_num) &
+        bind(C, name="trexio_to_orbital_list")
      import
      integer(c_int32_t), intent(in), value :: N_int
      integer(c_int64_t), intent(in)        :: d1(*)
@@ -6535,8 +6621,10 @@ end interface
 
    #+begin_src f90 :tangle prefix_fortran.f90
 interface
-   integer(trexio_exit_code) function trexio_to_orbital_list_up_dn_c(N_int, d1, list_up, list_dn, occ_num_up, occ_num_dn) &
-   bind(C, name="trexio_to_orbital_list_up_dn")
+   integer(trexio_exit_code) function &
+        trexio_to_orbital_list_up_dn_c &
+        (N_int, d1, list_up, list_dn, occ_num_up, occ_num_dn) &
+        bind(C, name="trexio_to_orbital_list_up_dn")
      import
      integer(c_int32_t), intent(in), value :: N_int
      integer(c_int64_t), intent(in)        :: d1(*)
@@ -6550,8 +6638,10 @@ end interface
 
   #+begin_src f90 :tangle prefix_fortran.f90
 interface
-  integer(trexio_exit_code) function trexio_convert_nao_radius_32(r, grid_r, log_r_out) &
-  bind(C, name="trexio_convert_nao_radius_32")
+  integer(trexio_exit_code) function &
+       trexio_convert_nao_radius_32 &
+       (r, grid_r, log_r_out) &
+       bind(C, name="trexio_convert_nao_radius_32")
     import
     real(c_float), intent(in), value  :: r
     real(c_float), intent(in)  :: grid_r(*)
@@ -6562,8 +6652,10 @@ end interface
 
   #+begin_src f90 :tangle prefix_fortran.f90
 interface
-  integer(trexio_exit_code) function trexio_convert_nao_radius_64(r, grid_r, log_r_out) &
-  bind(C, name="trexio_convert_nao_radius_64")
+  integer(trexio_exit_code) function &
+       trexio_convert_nao_radius_64 &
+       (r, grid_r, log_r_out) &
+       bind(C, name="trexio_convert_nao_radius_64")
     import
     real(c_double), intent(in), value  :: r
     real(c_double), intent(in)  :: grid_r(*)
@@ -6574,9 +6666,11 @@ end interface
 
   #+begin_src f90 :tangle prefix_fortran.f90
 interface
-  integer(trexio_exit_code) function trexio_evaluate_nao_radial (shell_index, r, &
-          grid_start, grid_size, grid_r, interpolator, normalization, amplitude) &
-  bind(C, name="trexio_evaluate_nao_radial")
+  integer(trexio_exit_code) function &
+       trexio_evaluate_nao_radial &
+       (shell_index, r, &
+       grid_start, grid_size, grid_r, interpolator, normalization, amplitude) &
+       bind(C, name="trexio_evaluate_nao_radial")
     import
     integer(c_int32_t), intent(in), value  :: shell_index
     real(c_double), intent(in), value   :: r
@@ -6592,11 +6686,12 @@ end interface
 
   #+begin_src f90 :tangle prefix_fortran.f90
 interface
-  integer(trexio_exit_code) function trexio_evaluate_nao_radial_all (shell_num, &
+  integer(trexio_exit_code) function &
+       trexio_evaluate_nao_radial_all (shell_num, &
           nucleus_index, nucleus_coords, &
           grid_start, grid_size, grid_r, interpolator, &
           normalization, rx, ry, rz, amplitudes) &
-  bind(C, name="trexio_evaluate_nao_radial_all")
+          bind(C, name="trexio_evaluate_nao_radial_all")
     import
     integer(c_int32_t), intent(in), value  :: shell_num
     integer(c_int32_t), intent(in) :: nucleus_index(*)
@@ -6884,7 +6979,9 @@ end subroutine trexio_string_of_error
   by 1 since in Fortran arrays are 1-based and C/Python they are 0-based.
 
   #+begin_src f90 :tangle helper_fortran.f90
-   integer(trexio_exit_code) function trexio_to_bitfield_list(list, occupied_num, det_list, N_int)
+   integer(trexio_exit_code) function &
+        trexio_to_bitfield_list &
+        (list, occupied_num, det_list, N_int)
      implicit none
 
      integer(c_int32_t), intent(in)        :: list(*)

--- a/tools/build_json.sh
+++ b/tools/build_json.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Check that script is executed from tools directory
+if [[ $(basename $PWD) != "tools" ]] ; then
+  echo "This script should run in the tools directory"
+  exit -1
+fi
+
+TREXIO_ROOT=$(dirname "${PWD}../")
+
+#   First define readonly global variables.
+readonly SRC=${TREXIO_ROOT}/src
+readonly TOOLS=${TREXIO_ROOT}/tools
+
+# Function to produce TREXIO source files from org-mode files
+function tangle()
+{
+  emacs --batch "$1" \
+        --load=${TOOLS}/emacs/config_tangle.el \
+        --eval "(progn
+              (require 'ob)
+              (require 'ob-python)
+              (org-babel-execute-buffer)
+              (org-babel-tangle))" &> /dev/null
+}
+
+# Create trex.json file
+cd ${TREXIO_ROOT}
+tangle trex.org
+

--- a/tools/build_trexio.sh
+++ b/tools/build_trexio.sh
@@ -25,10 +25,6 @@ function tangle()
 #        --eval "(org-babel-do-load-languages 'org-babel-load-languages '((python . t)))" \
 #        --eval "(setq org-confirm-babel-evaluate nil)" \
 
-# Create trex.json file
-cd ${TREXIO_ROOT}
-tangle trex.org
-
 # Go to src directory
 cd ${SRC}
 

--- a/tools/emacs/config_tangle.el
+++ b/tools/emacs/config_tangle.el
@@ -30,4 +30,3 @@
 
 (setq org-babel-python-command "python3 -q")
 (setq python-indent-guess-indent-offset-verbose nil) ;; Remove warning : Can’t guess python-indent-offset 
-

--- a/trex.org
+++ b/trex.org
@@ -13,6 +13,8 @@
 {
    #+end_src
 
+   #+RESULTS:
+
    Dimensions are given both in row-major ~[]~ and column-major ~()~
    formats. Pick the one adapted to the programming language in which
    you use TREXIO (Numpy is by default row-major, and Fortran is column-major).
@@ -47,19 +49,23 @@
   value can be manually overwritten (in unsafe mode) from ~1~ to ~0~.
 
   #+CALL: json(data=metadata, title="metadata")
+
   #+RESULTS:
   :results:
   #+begin_src python :tangle trex.json
       "metadata": {
-                 "code_num" : [ "dim", []                        ]
-        ,            "code" : [ "str", [ "metadata.code_num" ]   ]
-        ,      "author_num" : [ "dim", []                        ]
-        ,          "author" : [ "str", [ "metadata.author_num" ] ]
-        , "package_version" : [ "str", []                        ]
-        ,     "description" : [ "str", []                        ]
-        ,          "unsafe" : [ "int", []                        ]
+		 "code_num" : [ "dim", []                        ]
+	,            "code" : [ "str", [ "metadata.code_num" ]   ]
+	,      "author_num" : [ "dim", []                        ]
+	,          "author" : [ "str", [ "metadata.author_num" ] ]
+	, "package_version" : [ "str", []                        ]
+	,     "description" : [ "str", []                        ]
+	,          "unsafe" : [ "int", []                        ]
       } ,
   #+end_src
+
+  #+RESULTS:
+
   :end:
 
 * System
@@ -69,28 +75,32 @@
    given in Cartesian $(x,y,z)$ format.
 
    #+NAME: nucleus
-  | Variable      | Type    | Row-major Dimensions | Column-major Dimensions | Description              |   |
-  |---------------+---------+----------------------+-------------------------+--------------------------+---|
-  | ~num~         | ~dim~   |                      |                         | Number of nuclei         |   |
-  | ~charge~      | ~float~ | ~[nucleus.num]~      | ~(nucleus.num)~         | Charges of the nuclei    |   |
-  | ~coord~       | ~float~ | ~[nucleus.num, 3]~   | ~(3, nucleus.num)~      | Coordinates of the atoms |   |
-  | ~label~       | ~str~   | ~[nucleus.num]~      | ~(nucleus.num)~         | Atom labels              |   |
-  | ~point_group~ | ~str~   |                      |                         | Symmetry point group     |   |
-  | ~repulsion~   | ~float~ |                      |                         | Nuclear repulsion energy |   |
+  | Variable      | Type    | Row-major Dimensions | Column-major Dimensions | Description              |
+  |---------------+---------+----------------------+-------------------------+--------------------------|
+  | ~num~         | ~dim~   |                      |                         | Number of nuclei         |
+  | ~charge~      | ~float~ | ~[nucleus.num]~      | ~(nucleus.num)~         | Charges of the nuclei    |
+  | ~coord~       | ~float~ | ~[nucleus.num, 3]~   | ~(3, nucleus.num)~      | Coordinates of the atoms |
+  | ~label~       | ~str~   | ~[nucleus.num]~      | ~(nucleus.num)~         | Atom labels              |
+  | ~point_group~ | ~str~   |                      |                         | Symmetry point group     |
+  | ~repulsion~   | ~float~ |                      |                         | Nuclear repulsion energy |
 
    #+CALL: json(data=nucleus, title="nucleus")
+
    #+RESULTS:
    :results:
    #+begin_src python :tangle trex.json
        "nucleus": {
-                   "num" : [ "dim"  , []                     ]
-         ,      "charge" : [ "float", [ "nucleus.num" ]      ]
-         ,       "coord" : [ "float", [ "nucleus.num", "3" ] ]
-         ,       "label" : [ "str"  , [ "nucleus.num" ]      ]
-         , "point_group" : [ "str"  , []                     ]
-         ,   "repulsion" : [ "float", []                     ]
+		   "num" : [ "dim"  , []                     ]
+	 ,      "charge" : [ "float", [ "nucleus.num" ]      ]
+	 ,       "coord" : [ "float", [ "nucleus.num", "3" ] ]
+	 ,       "label" : [ "str"  , [ "nucleus.num" ]      ]
+	 , "point_group" : [ "str"  , []                     ]
+	 ,   "repulsion" : [ "float", []                     ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 ** Cell (cell group)
@@ -115,15 +125,18 @@
    :results:
    #+begin_src python :tangle trex.json
        "cell": {
-                "a" : [ "float", [ "3" ] ]
-         ,      "b" : [ "float", [ "3" ] ]
-         ,      "c" : [ "float", [ "3" ] ]
-         ,    "g_a" : [ "float", [ "3" ] ]
-         ,    "g_b" : [ "float", [ "3" ] ]
-         ,    "g_c" : [ "float", [ "3" ] ]
-         , "two_pi" : [ "int"  , []      ]
+		"a" : [ "float", [ "3" ] ]
+	 ,      "b" : [ "float", [ "3" ] ]
+	 ,      "c" : [ "float", [ "3" ] ]
+	 ,    "g_a" : [ "float", [ "3" ] ]
+	 ,    "g_b" : [ "float", [ "3" ] ]
+	 ,    "g_c" : [ "float", [ "3" ] ]
+	 , "two_pi" : [ "int"  , []      ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 ** Periodic boundary calculations (pbc group)
@@ -144,13 +157,16 @@
    :results:
    #+begin_src python :tangle trex.json
        "pbc": {
-                 "periodic" : [ "int"  , []                    ]
-         ,    "k_point_num" : [ "dim"  , []                    ]
-         ,        "k_point" : [ "float", [ "3" ]               ]
-         , "k_point_weight" : [ "float", [ "pbc.k_point_num" ] ]
-         ,       "madelung" : [ "float", []                    ]
+		 "periodic" : [ "int"  , []                    ]
+	 ,    "k_point_num" : [ "dim"  , []                    ]
+	 ,        "k_point" : [ "float", [ "3" ]               ]
+	 , "k_point_weight" : [ "float", [ "pbc.k_point_num" ] ]
+	 ,       "madelung" : [ "float", []                    ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 ** Electron (electron group)
@@ -176,15 +192,19 @@
   | ~dn_num~ | ~int~ |                      |                         | Number of \downarrow-spin electrons |
 
    #+CALL: json(data=electron, title="electron")
+
    #+RESULTS:
    :results:
    #+begin_src python :tangle trex.json
        "electron": {
-              "num" : [ "dim", []  ]
-         , "up_num" : [ "int", []  ]
-         , "dn_num" : [ "int", []  ]
+	      "num" : [ "dim", []  ]
+	 , "up_num" : [ "int", []  ]
+	 , "dn_num" : [ "int", []  ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 ** Ground or excited states (state group)
@@ -216,14 +236,17 @@
    :results:
    #+begin_src python :tangle trex.json
        "state": {
-                     "num" : [ "dim"  , []              ]
-         ,            "id" : [ "index", []              ]
-         ,        "energy" : [ "float", []              ]
-         , "current_label" : [ "str"  , []              ]
-         ,         "label" : [ "str"  , [ "state.num" ] ]
-         ,     "file_name" : [ "str"  , [ "state.num" ] ]
+		     "num" : [ "dim"  , []              ]
+	 ,            "id" : [ "index", []              ]
+	 ,        "energy" : [ "float", []              ]
+	 , "current_label" : [ "str"  , []              ]
+	 ,         "label" : [ "str"  , [ "state.num" ] ]
+	 ,     "file_name" : [ "str"  , [ "state.num" ] ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 * Basis functions
@@ -389,37 +412,40 @@
     #+RESULTS:
     :results:
     #+begin_src python :tangle trex.json
-        "basis": {
-                         "type" : [ "str"  , []                                                 ]
-          ,          "prim_num" : [ "dim"  , []                                                 ]
-          ,         "shell_num" : [ "dim"  , []                                                 ]
-          ,      "nao_grid_num" : [ "dim"  , []                                                 ]
-          ,  "interp_coeff_cnt" : [ "dim"  , []                                                 ]
-          ,     "nucleus_index" : [ "index", [ "basis.shell_num" ]                              ]
-          ,     "shell_ang_mom" : [ "int"  , [ "basis.shell_num" ]                              ]
-          ,      "shell_factor" : [ "float", [ "basis.shell_num" ]                              ]
-          ,           "r_power" : [ "int"  , [ "basis.shell_num" ]                              ]
-          ,    "nao_grid_start" : [ "index", [ "basis.shell_num" ]                              ]
-          ,     "nao_grid_size" : [ "dim"  , [ "basis.shell_num" ]                              ]
-          ,       "shell_index" : [ "index", [ "basis.prim_num" ]                               ]
-          ,          "exponent" : [ "float", [ "basis.prim_num" ]                               ]
-          ,       "exponent_im" : [ "float", [ "basis.prim_num" ]                               ]
-          ,       "coefficient" : [ "float", [ "basis.prim_num" ]                               ]
-          ,    "coefficient_im" : [ "float", [ "basis.prim_num" ]                               ]
-          ,   "oscillation_arg" : [ "float", [ "basis.prim_num" ]                               ]
-          ,  "oscillation_kind" : [ "str"  , []                                                 ]
-          ,       "prim_factor" : [ "float", [ "basis.prim_num" ]                               ]
-          ,             "e_cut" : [ "float", []                                                 ]
-          ,   "nao_grid_radius" : [ "float", [ "basis.nao_grid_num" ]                           ]
-          ,      "nao_grid_phi" : [ "float", [ "basis.nao_grid_num" ]                           ]
-          ,     "nao_grid_grad" : [ "float", [ "basis.nao_grid_num" ]                           ]
-          ,      "nao_grid_lap" : [ "float", [ "basis.nao_grid_num" ]                           ]
-          , "interpolator_kind" : [ "str"  , []                                                 ]
-          ,  "interpolator_phi" : [ "float", [ "basis.nao_grid_num", "basis.interp_coeff_cnt" ] ]
-          , "interpolator_grad" : [ "float", [ "basis.nao_grid_num", "basis.interp_coeff_cnt" ] ]
-          ,  "interpolator_lap" : [ "float", [ "basis.nao_grid_num", "basis.interp_coeff_cnt" ] ]
-        } ,
+	"basis": {
+			 "type" : [ "str"  , []                                                 ]
+	  ,          "prim_num" : [ "dim"  , []                                                 ]
+	  ,         "shell_num" : [ "dim"  , []                                                 ]
+	  ,      "nao_grid_num" : [ "dim"  , []                                                 ]
+	  ,  "interp_coeff_cnt" : [ "dim"  , []                                                 ]
+	  ,     "nucleus_index" : [ "index", [ "basis.shell_num" ]                              ]
+	  ,     "shell_ang_mom" : [ "int"  , [ "basis.shell_num" ]                              ]
+	  ,      "shell_factor" : [ "float", [ "basis.shell_num" ]                              ]
+	  ,           "r_power" : [ "int"  , [ "basis.shell_num" ]                              ]
+	  ,    "nao_grid_start" : [ "index", [ "basis.shell_num" ]                              ]
+	  ,     "nao_grid_size" : [ "dim"  , [ "basis.shell_num" ]                              ]
+	  ,       "shell_index" : [ "index", [ "basis.prim_num" ]                               ]
+	  ,          "exponent" : [ "float", [ "basis.prim_num" ]                               ]
+	  ,       "exponent_im" : [ "float", [ "basis.prim_num" ]                               ]
+	  ,       "coefficient" : [ "float", [ "basis.prim_num" ]                               ]
+	  ,    "coefficient_im" : [ "float", [ "basis.prim_num" ]                               ]
+	  ,   "oscillation_arg" : [ "float", [ "basis.prim_num" ]                               ]
+	  ,  "oscillation_kind" : [ "str"  , []                                                 ]
+	  ,       "prim_factor" : [ "float", [ "basis.prim_num" ]                               ]
+	  ,             "e_cut" : [ "float", []                                                 ]
+	  ,   "nao_grid_radius" : [ "float", [ "basis.nao_grid_num" ]                           ]
+	  ,      "nao_grid_phi" : [ "float", [ "basis.nao_grid_num" ]                           ]
+	  ,     "nao_grid_grad" : [ "float", [ "basis.nao_grid_num" ]                           ]
+	  ,      "nao_grid_lap" : [ "float", [ "basis.nao_grid_num" ]                           ]
+	  , "interpolator_kind" : [ "str"  , []                                                 ]
+	  ,  "interpolator_phi" : [ "float", [ "basis.nao_grid_num", "basis.interp_coeff_cnt" ] ]
+	  , "interpolator_grad" : [ "float", [ "basis.nao_grid_num", "basis.interp_coeff_cnt" ] ]
+	  ,  "interpolator_lap" : [ "float", [ "basis.nao_grid_num", "basis.interp_coeff_cnt" ] ]
+	} ,
     #+end_src
+
+    #+RESULTS:
+
     :end:
 
 *** Example
@@ -557,16 +583,19 @@ prim_factor =
    :results:
    #+begin_src python :tangle trex.json
        "ecp": {
-           "max_ang_mom_plus_1" : [ "int"  , [ "nucleus.num" ] ]
-         ,             "z_core" : [ "int"  , [ "nucleus.num" ] ]
-         ,                "num" : [ "dim"  , []                ]
-         ,            "ang_mom" : [ "int"  , [ "ecp.num" ]     ]
-         ,      "nucleus_index" : [ "index", [ "ecp.num" ]     ]
-         ,           "exponent" : [ "float", [ "ecp.num" ]     ]
-         ,        "coefficient" : [ "float", [ "ecp.num" ]     ]
-         ,              "power" : [ "int"  , [ "ecp.num" ]     ]
+	   "max_ang_mom_plus_1" : [ "int"  , [ "nucleus.num" ] ]
+	 ,             "z_core" : [ "int"  , [ "nucleus.num" ] ]
+	 ,                "num" : [ "dim"  , []                ]
+	 ,            "ang_mom" : [ "int"  , [ "ecp.num" ]     ]
+	 ,      "nucleus_index" : [ "index", [ "ecp.num" ]     ]
+	 ,           "exponent" : [ "float", [ "ecp.num" ]     ]
+	 ,        "coefficient" : [ "float", [ "ecp.num" ]     ]
+	 ,              "power" : [ "int"  , [ "ecp.num" ]     ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 *** Example
@@ -658,22 +687,25 @@ power = [
     #+RESULTS:
     :results:
     #+begin_src python :tangle trex.json
-        "grid": {
-              "description" : [ "str"  , []                 ]
-          , "rad_precision" : [ "float", []                 ]
-          ,           "num" : [ "dim"  , []                 ]
-          ,   "max_ang_num" : [ "int"  , []                 ]
-          ,   "min_ang_num" : [ "int"  , []                 ]
-          ,         "coord" : [ "float", [ "grid.num" ]     ]
-          ,        "weight" : [ "float", [ "grid.num" ]     ]
-          ,       "ang_num" : [ "dim"  , []                 ]
-          ,     "ang_coord" : [ "float", [ "grid.ang_num" ] ]
-          ,    "ang_weight" : [ "float", [ "grid.ang_num" ] ]
-          ,       "rad_num" : [ "dim"  , []                 ]
-          ,     "rad_coord" : [ "float", [ "grid.rad_num" ] ]
-          ,    "rad_weight" : [ "float", [ "grid.rad_num" ] ]
-        } ,
+	"grid": {
+	      "description" : [ "str"  , []                 ]
+	  , "rad_precision" : [ "float", []                 ]
+	  ,           "num" : [ "dim"  , []                 ]
+	  ,   "max_ang_num" : [ "int"  , []                 ]
+	  ,   "min_ang_num" : [ "int"  , []                 ]
+	  ,         "coord" : [ "float", [ "grid.num" ]     ]
+	  ,        "weight" : [ "float", [ "grid.num" ]     ]
+	  ,       "ang_num" : [ "dim"  , []                 ]
+	  ,     "ang_coord" : [ "float", [ "grid.ang_num" ] ]
+	  ,    "ang_weight" : [ "float", [ "grid.ang_num" ] ]
+	  ,       "rad_num" : [ "dim"  , []                 ]
+	  ,     "rad_coord" : [ "float", [ "grid.rad_num" ] ]
+	  ,    "rad_weight" : [ "float", [ "grid.rad_num" ] ]
+	} ,
     #+end_src
+
+    #+RESULTS:
+
     :end:
 
 * Orbitals
@@ -736,12 +768,15 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "ao": {
-               "cartesian" : [ "int"  , []           ]
-         ,           "num" : [ "dim"  , []           ]
-         ,         "shell" : [ "index", [ "ao.num" ] ]
-         , "normalization" : [ "float", [ "ao.num" ] ]
+	       "cartesian" : [ "int"  , []           ]
+	 ,           "num" : [ "dim"  , []           ]
+	 ,         "shell" : [ "index", [ "ao.num" ] ]
+	 , "normalization" : [ "float", [ "ao.num" ] ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 *** One-electron integrals (~ao_1e_int~ group)
@@ -779,19 +814,22 @@ power = [
     #+RESULTS:
     :results:
     #+begin_src python :tangle trex.json
-        "ao_1e_int": {
-                        "overlap" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,             "kinetic" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,       "potential_n_e" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,                 "ecp" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,    "core_hamiltonian" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,          "overlap_im" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,          "kinetic_im" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,    "potential_n_e_im" : [ "float", [ "ao.num", "ao.num" ] ]
-          ,              "ecp_im" : [ "float", [ "ao.num", "ao.num" ] ]
-          , "core_hamiltonian_im" : [ "float", [ "ao.num", "ao.num" ] ]
-        } ,
+	"ao_1e_int": {
+			"overlap" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,             "kinetic" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,       "potential_n_e" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,                 "ecp" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,    "core_hamiltonian" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,          "overlap_im" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,          "kinetic_im" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,    "potential_n_e_im" : [ "float", [ "ao.num", "ao.num" ] ]
+	  ,              "ecp_im" : [ "float", [ "ao.num", "ao.num" ] ]
+	  , "core_hamiltonian_im" : [ "float", [ "ao.num", "ao.num" ] ]
+	} ,
     #+end_src
+
+    #+RESULTS:
+
     :end:
 
 *** Two-electron integrals (~ao_2e_int~ group)
@@ -833,15 +871,18 @@ power = [
     #+RESULTS:
     :results:
     #+begin_src python :tangle trex.json
-        "ao_2e_int": {
-                            "eri" : [ "float sparse", [ "ao.num", "ao.num", "ao.num", "ao.num" ]              ]
-          ,              "eri_lr" : [ "float sparse", [ "ao.num", "ao.num", "ao.num", "ao.num" ]              ]
-          ,    "eri_cholesky_num" : [ "dim"         , []                                                      ]
-          ,        "eri_cholesky" : [ "float sparse", [ "ao_2e_int.eri_cholesky_num", "ao.num", "ao.num" ]    ]
-          , "eri_lr_cholesky_num" : [ "dim"         , []                                                      ]
-          ,     "eri_lr_cholesky" : [ "float sparse", [ "ao_2e_int.eri_lr_cholesky_num", "ao.num", "ao.num" ] ]
-        } ,
+	"ao_2e_int": {
+			    "eri" : [ "float sparse", [ "ao.num", "ao.num", "ao.num", "ao.num" ]              ]
+	  ,              "eri_lr" : [ "float sparse", [ "ao.num", "ao.num", "ao.num", "ao.num" ]              ]
+	  ,    "eri_cholesky_num" : [ "dim"         , []                                                      ]
+	  ,        "eri_cholesky" : [ "float sparse", [ "ao_2e_int.eri_cholesky_num", "ao.num", "ao.num" ]    ]
+	  , "eri_lr_cholesky_num" : [ "dim"         , []                                                      ]
+	  ,     "eri_lr_cholesky" : [ "float sparse", [ "ao_2e_int.eri_lr_cholesky_num", "ao.num", "ao.num" ] ]
+	} ,
     #+end_src
+
+    #+RESULTS:
+
     :end:
 
 ** Molecular orbitals (mo group)
@@ -872,18 +913,21 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "mo": {
-                     "type" : [ "str"  , []                     ]
-         ,            "num" : [ "dim"  , []                     ]
-         ,    "coefficient" : [ "float", [ "mo.num", "ao.num" ] ]
-         , "coefficient_im" : [ "float", [ "mo.num", "ao.num" ] ]
-         ,          "class" : [ "str"  , [ "mo.num" ]           ]
-         ,       "symmetry" : [ "str"  , [ "mo.num" ]           ]
-         ,     "occupation" : [ "float", [ "mo.num" ]           ]
-         ,         "energy" : [ "float", [ "mo.num" ]           ]
-         ,           "spin" : [ "int"  , [ "mo.num" ]           ]
-         ,        "k_point" : [ "index", [ "mo.num" ]           ]
+		     "type" : [ "str"  , []                     ]
+	 ,            "num" : [ "dim"  , []                     ]
+	 ,    "coefficient" : [ "float", [ "mo.num", "ao.num" ] ]
+	 , "coefficient_im" : [ "float", [ "mo.num", "ao.num" ] ]
+	 ,          "class" : [ "str"  , [ "mo.num" ]           ]
+	 ,       "symmetry" : [ "str"  , [ "mo.num" ]           ]
+	 ,     "occupation" : [ "float", [ "mo.num" ]           ]
+	 ,         "energy" : [ "float", [ "mo.num" ]           ]
+	 ,           "spin" : [ "int"  , [ "mo.num" ]           ]
+	 ,        "k_point" : [ "index", [ "mo.num" ]           ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 
@@ -912,19 +956,22 @@ power = [
     #+RESULTS:
     :results:
     #+begin_src python :tangle trex.json
-        "mo_1e_int": {
-                        "overlap" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,             "kinetic" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,       "potential_n_e" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,                 "ecp" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,    "core_hamiltonian" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,          "overlap_im" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,          "kinetic_im" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,    "potential_n_e_im" : [ "float", [ "mo.num", "mo.num" ] ]
-          ,              "ecp_im" : [ "float", [ "mo.num", "mo.num" ] ]
-          , "core_hamiltonian_im" : [ "float", [ "mo.num", "mo.num" ] ]
-        } ,
+	"mo_1e_int": {
+			"overlap" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,             "kinetic" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,       "potential_n_e" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,                 "ecp" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,    "core_hamiltonian" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,          "overlap_im" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,          "kinetic_im" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,    "potential_n_e_im" : [ "float", [ "mo.num", "mo.num" ] ]
+	  ,              "ecp_im" : [ "float", [ "mo.num", "mo.num" ] ]
+	  , "core_hamiltonian_im" : [ "float", [ "mo.num", "mo.num" ] ]
+	} ,
     #+end_src
+
+    #+RESULTS:
+
     :end:
 
 *** Two-electron integrals (~mo_2e_int~ group)
@@ -948,15 +995,18 @@ power = [
     #+RESULTS:
     :results:
     #+begin_src python :tangle trex.json
-        "mo_2e_int": {
-                            "eri" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]              ]
-          ,              "eri_lr" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]              ]
-          ,    "eri_cholesky_num" : [ "dim"         , []                                                      ]
-          ,        "eri_cholesky" : [ "float sparse", [ "mo_2e_int.eri_cholesky_num", "mo.num", "mo.num" ]    ]
-          , "eri_lr_cholesky_num" : [ "dim"         , []                                                      ]
-          ,     "eri_lr_cholesky" : [ "float sparse", [ "mo_2e_int.eri_lr_cholesky_num", "mo.num", "mo.num" ] ]
-        } ,
+	"mo_2e_int": {
+			    "eri" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]              ]
+	  ,              "eri_lr" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]              ]
+	  ,    "eri_cholesky_num" : [ "dim"         , []                                                      ]
+	  ,        "eri_cholesky" : [ "float sparse", [ "mo_2e_int.eri_cholesky_num", "mo.num", "mo.num" ]    ]
+	  , "eri_lr_cholesky_num" : [ "dim"         , []                                                      ]
+	  ,     "eri_lr_cholesky" : [ "float sparse", [ "mo_2e_int.eri_lr_cholesky_num", "mo.num", "mo.num" ] ]
+	} ,
     #+end_src
+
+    #+RESULTS:
+
     :end:
 
 * Multi-determinant information
@@ -1001,11 +1051,14 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "determinant": {
-                   "num" : [ "dim readonly"  , []                    ]
-         ,        "list" : [ "int special"   , [ "determinant.num" ] ]
-         , "coefficient" : [ "float buffered", [ "determinant.num" ] ]
+		   "num" : [ "dim readonly"  , []                    ]
+	 ,        "list" : [ "int special"   , [ "determinant.num" ] ]
+	 , "coefficient" : [ "float buffered", [ "determinant.num" ] ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 ** Configuration state functions (csf group)
@@ -1037,11 +1090,14 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "csf": {
-                       "num" : [ "dim readonly"  , []                               ]
-         ,     "coefficient" : [ "float buffered", [ "csf.num" ]                    ]
-         , "det_coefficient" : [ "float sparse"  , [ "csf.num", "determinant.num" ] ]
+		       "num" : [ "dim readonly"  , []                               ]
+	 ,     "coefficient" : [ "float buffered", [ "csf.num" ]                    ]
+	 , "det_coefficient" : [ "float sparse"  , [ "csf.num", "determinant.num" ] ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 ** Amplitudes (amplitude group)
@@ -1105,16 +1161,19 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "amplitude": {
-                  "single" : [ "float sparse", [ "mo.num", "mo.num" ]                                                             ]
-         ,    "single_exp" : [ "float sparse", [ "mo.num", "mo.num" ]                                                             ]
-         ,        "double" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                                         ]
-         ,    "double_exp" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                                         ]
-         ,        "triple" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ]                     ]
-         ,    "triple_exp" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ]                     ]
-         ,     "quadruple" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ] ]
-         , "quadruple_exp" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ] ]
+		  "single" : [ "float sparse", [ "mo.num", "mo.num" ]                                                             ]
+	 ,    "single_exp" : [ "float sparse", [ "mo.num", "mo.num" ]                                                             ]
+	 ,        "double" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                                         ]
+	 ,    "double_exp" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                                         ]
+	 ,        "triple" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ]                     ]
+	 ,    "triple_exp" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ]                     ]
+	 ,     "quadruple" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ] ]
+	 , "quadruple_exp" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num", "mo.num" ] ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 ** Reduced density matrices (rdm group)
@@ -1198,25 +1257,28 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "rdm": {
-                             "1e" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
-         ,                "1e_up" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
-         ,                "1e_dn" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
-         ,        "1e_transition" : [ "float"       , [ "state.num", "state.num", "mo.num", "mo.num" ]                     ]
-         ,                   "2e" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
-         ,              "2e_upup" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
-         ,              "2e_dndn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
-         ,              "2e_updn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
-         ,        "2e_transition" : [ "float sparse", [ "state.num", "state.num", "mo.num", "mo.num", "mo.num", "mo.num" ] ]
-         ,      "2e_cholesky_num" : [ "dim"         , []                                                                   ]
-         ,          "2e_cholesky" : [ "float sparse", [ "rdm.2e_cholesky_num", "mo.num", "mo.num" ]                        ]
-         , "2e_upup_cholesky_num" : [ "dim"         , []                                                                   ]
-         ,     "2e_upup_cholesky" : [ "float sparse", [ "rdm.2e_upup_cholesky_num", "mo.num", "mo.num" ]                   ]
-         , "2e_dndn_cholesky_num" : [ "dim"         , []                                                                   ]
-         ,     "2e_dndn_cholesky" : [ "float sparse", [ "rdm.2e_dndn_cholesky_num", "mo.num", "mo.num" ]                   ]
-         , "2e_updn_cholesky_num" : [ "dim"         , []                                                                   ]
-         ,     "2e_updn_cholesky" : [ "float sparse", [ "rdm.2e_updn_cholesky_num", "mo.num", "mo.num" ]                   ]
+			     "1e" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
+	 ,                "1e_up" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
+	 ,                "1e_dn" : [ "float"       , [ "mo.num", "mo.num" ]                                               ]
+	 ,        "1e_transition" : [ "float"       , [ "state.num", "state.num", "mo.num", "mo.num" ]                     ]
+	 ,                   "2e" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+	 ,              "2e_upup" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+	 ,              "2e_dndn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+	 ,              "2e_updn" : [ "float sparse", [ "mo.num", "mo.num", "mo.num", "mo.num" ]                           ]
+	 ,        "2e_transition" : [ "float sparse", [ "state.num", "state.num", "mo.num", "mo.num", "mo.num", "mo.num" ] ]
+	 ,      "2e_cholesky_num" : [ "dim"         , []                                                                   ]
+	 ,          "2e_cholesky" : [ "float sparse", [ "rdm.2e_cholesky_num", "mo.num", "mo.num" ]                        ]
+	 , "2e_upup_cholesky_num" : [ "dim"         , []                                                                   ]
+	 ,     "2e_upup_cholesky" : [ "float sparse", [ "rdm.2e_upup_cholesky_num", "mo.num", "mo.num" ]                   ]
+	 , "2e_dndn_cholesky_num" : [ "dim"         , []                                                                   ]
+	 ,     "2e_dndn_cholesky" : [ "float sparse", [ "rdm.2e_dndn_cholesky_num", "mo.num", "mo.num" ]                   ]
+	 , "2e_updn_cholesky_num" : [ "dim"         , []                                                                   ]
+	 ,     "2e_updn_cholesky" : [ "float sparse", [ "rdm.2e_updn_cholesky_num", "mo.num", "mo.num" ]                   ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 * Correlation factors
@@ -1397,19 +1459,22 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "jastrow": {
-                  "type" : [ "str"  , []                    ]
-         ,      "en_num" : [ "dim"  , []                    ]
-         ,      "ee_num" : [ "dim"  , []                    ]
-         ,     "een_num" : [ "dim"  , []                    ]
-         ,          "en" : [ "float", [ "jastrow.en_num" ]  ]
-         ,          "ee" : [ "float", [ "jastrow.ee_num" ]  ]
-         ,         "een" : [ "float", [ "jastrow.een_num" ] ]
-         ,  "en_nucleus" : [ "index", [ "jastrow.en_num" ]  ]
-         , "een_nucleus" : [ "index", [ "jastrow.een_num" ] ]
-         ,  "ee_scaling" : [ "float", []                    ]
-         ,  "en_scaling" : [ "float", [ "nucleus.num" ]     ]
+		  "type" : [ "str"  , []                    ]
+	 ,      "en_num" : [ "dim"  , []                    ]
+	 ,      "ee_num" : [ "dim"  , []                    ]
+	 ,     "een_num" : [ "dim"  , []                    ]
+	 ,          "en" : [ "float", [ "jastrow.en_num" ]  ]
+	 ,          "ee" : [ "float", [ "jastrow.ee_num" ]  ]
+	 ,         "een" : [ "float", [ "jastrow.een_num" ] ]
+	 ,  "en_nucleus" : [ "index", [ "jastrow.en_num" ]  ]
+	 , "een_nucleus" : [ "index", [ "jastrow.een_num" ] ]
+	 ,  "ee_scaling" : [ "float", []                    ]
+	 ,  "en_scaling" : [ "float", [ "nucleus.num" ]     ]
        } ,
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 * Quantum Monte Carlo data (qmc group)
@@ -1436,66 +1501,80 @@ power = [
    :results:
    #+begin_src python :tangle trex.json
        "qmc": {
-             "num" : [ "dim"  , []                                 ]
-         , "point" : [ "float", [ "qmc.num", "electron.num", "3" ] ]
-         ,   "psi" : [ "float", [ "qmc.num" ]                      ]
-         , "e_loc" : [ "float", [ "qmc.num" ]                      ]
+	     "num" : [ "dim"  , []                                 ]
+	 , "point" : [ "float", [ "qmc.num", "electron.num", "3" ] ]
+	 ,   "psi" : [ "float", [ "qmc.num" ]                      ]
+	 , "e_loc" : [ "float", [ "qmc.num" ]                      ]
        }
    #+end_src
+
+   #+RESULTS:
+
    :end:
 
 * Appendix    :noexport:
 ** Python script from table to json
 
  #+NAME: json
- #+begin_src python :var data=nucleus title="nucleus" last=0 :results output drawer
+ #+begin_src python :var data=nucleus title="End" last=0 :results output drawer
 print("""#+begin_src python :tangle trex.json""")
-print("""    "%s": {"""%(title))
-indent = "        "
-f1 = 0 ; f2 = 0 ; f3 = 0
-for line in data:
-    line = [ x.replace("~","") for x in line ]
-    name = '"'+line[0]+'"'
-    typ  = '"'+line[1]+'"'
-    dims = line[2]
-    if '[' in dims:
-        dims = dims.strip()[1:-1]
-        dims = [ '"'+x.strip()+'"' for x in dims.split(',') ]
-        dims = "[ " + ", ".join(dims) + " ]"
-    else:
-        dims = "[ ]"
-    f1 = max(f1, len(name))
-    f2 = max(f2, len(typ))
-    f3 = max(f3, len(dims))
-
-fmt = "%%s%%%ds : [ %%%ds, %%%ds ]" % (f1, f2, f3)
-for line in data:
-    line = [ x.replace("~","") for x in line ]
-    name = '"'+line[0]+'"'
-    typ  = '"'+line[1]+'"'
-    dims = line[2]
-    if '[' in dims:
-        dims = dims.strip()[1:-1]
-        dims = [ '"'+x.strip()+'"' for x in dims.split(',') ]
-        dims = "[ " + ", ".join(dims) + " ]"
-    else:
-        if dims.strip() != "":
-            dims = "ERROR"
+if title != "End":
+    print("""    "%s": {"""%(title))
+    indent = "        "
+    f1 = 0 ; f2 = 0 ; f3 = 0
+    for line in data:
+        line = [ x.replace("~","") for x in line ]
+        name = '"'+line[0]+'"'
+        typ  = '"'+line[1]+'"'
+        dims = line[2]
+        if '[' in dims:
+            dims = dims.strip()[1:-1]
+            dims = [ '"'+x.strip()+'"' for x in dims.split(',') ]
+            dims = "[ " + ", ".join(dims) + " ]"
         else:
-            dims = "[]"
-    buffer = fmt % (indent, name, typ.ljust(f2), dims.ljust(f3))
-    indent = "      , "
-    print(buffer)
-
-if last == 0:
-    print("    } ,")
+            dims = "[ ]"
+        f1 = max(f1, len(name))
+        f2 = max(f2, len(typ))
+        f3 = max(f3, len(dims))
+    
+    fmt = "%%s%%%ds : [ %%%ds, %%%ds ]" % (f1, f2, f3)
+    for line in data:
+        line = [ x.replace("~","") for x in line ]
+        name = '"'+line[0]+'"'
+        typ  = '"'+line[1]+'"'
+        dims = line[2]
+        if '[' in dims:
+            dims = dims.strip()[1:-1]
+            dims = [ '"'+x.strip()+'"' for x in dims.split(',') ]
+            dims = "[ " + ", ".join(dims) + " ]"
+        else:
+            if dims.strip() != "":
+                dims = "ERROR"
+            else:
+                dims = "[]"
+        buffer = fmt % (indent, name, typ.ljust(f2), dims.ljust(f3))
+        indent = "      , "
+        print(buffer)
+    
+    if last == 0:
+        print("    } ,")
+    else:
+        print("    }")
 else:
-    print("    }")
-print("""#+end_src""")
+    print("}")
 
+print("""#+end_src""")
  #+end_src
 
+ #+RESULTS: json
+ :results:
+ #+begin_src python :tangle trex.json
+ }
+ #+end_src
 
-  #+begin_src python :tangle trex.json :results output drawer :exports none
-}
-  #+end_src
+ #+RESULTS:
+
+ :end:
+
+
+


### PR DESCRIPTION
This should fix #180 
I modified the templates in the front-end to add line-continuation characters, so that the generated function names are alone in their line.