### PR TITLE
Simplified configure.ac in hdf5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,29 +122,33 @@ AC_CHECK_HEADERS([fcntl.h inttypes.h stdint.h stdbool.h stdlib.h string.h unistd
 ### HDF5
 ### ----
 
+# Initialize variables
 PKG_HDF5=""
 HDF5_LIBS=""
 HDF5_LDFLAGS=""
 HDF5_CFLAGS=""
 HDF5_CPPFLAGS=""
-AC_ARG_WITH([hdf5],
-  AS_HELP_STRING([--with-hdf5=PATH], [Path to HDF5 library and headers]), [
-  with_hdf5="$withval"], [with_hdf5="yes"])
 
-AS_IF([test "x$with_hdf5" == "xno"], [],
-      [test "x$with_hdf5" != "xyes"], [
-           HDF5_LIBS="-lhdf5"
-           HDF5_PATH="$with_hdf5"
-           HDF5_LDFLAGS="-L$HDF5_PATH/lib"
-           HDF5_CPPFLAGS="-I$HDF5_PATH/include"
-           AC_DEFINE([HAVE_HDF5], 1, [Define to 1 if HDF5 is available]) ],
-      [
-           PKG_CHECK_EXISTS([hdf5], [
-             PKG_CHECK_MODULES([HDF5], [hdf5 >= 1.8])
-             PKG_HDF5="hdf5"
-           ],
-           [ AC_PATH_PROG([H5CC],[h5cc],[not_found])
-             AS_IF([test "$H5CC" != "not_found"], [
+AC_ARG_WITH([hdf5],
+  AS_HELP_STRING([--with-hdf5=PATH], [Use HDF5 (yes|no|/custom/path)]),
+  [],
+  [with_hdf5=yes])
+
+AS_IF([test "x$with_hdf5" = "xno"],
+  [AC_MSG_NOTICE([HDF5 support disabled by user.])],
+  [AS_IF([test "x$with_hdf5" = "xyes"],
+    [
+      # Try pkg-config first
+      PKG_CHECK_EXISTS([hdf5 >= 1.8],
+        [
+          PKG_CHECK_MODULES([HDF5], [hdf5 >= 1.8])
+          PKG_HDF5="hdf5"
+        ],
+        [
+          # Fallback: Try to find h5cc
+          AC_PATH_PROG([H5CC], [h5cc], [not_found])
+          AS_IF([test "$H5CC" != "not_found"],
+            [
               HDF5_LIBS="-lhdf5"
               AC_REQUIRE([AC_PROG_SED])
               AC_REQUIRE([AC_PROG_AWK])
@@ -190,32 +194,54 @@ AS_IF([test "x$with_hdf5" == "xno"], [],
                     ;;
                 esac
               done
+            ],
+            [AC_MSG_ERROR([HDF5 not found: install pkg-config .pc file or h5cc, or use --with-hdf5=PATH])]
+          )
+        ]
+      )
+    ],
+    [
+      # User-provided path
+      HDF5_PATH="$with_hdf5"
+      HDF5_LDFLAGS="-L$HDF5_PATH/lib"
+      HDF5_CPPFLAGS="-I$HDF5_PATH/include"
+      HDF5_LIBS="-lhdf5"
+    ]
+  )
 
-             ])
-           ])
-           AC_DEFINE([HAVE_HDF5], 1, [Define to 1 if HDF5 is available])
-      ])
+  AC_DEFINE([HAVE_HDF5], 1, [Define to 1 if HDF5 is available])
+  AM_CONDITIONAL([HAVE_HDF5], [true])
+])
 
-AM_CONDITIONAL([HAVE_HDF5],[test "x$with_hdf5" != "xno"])
-
+# Export variables to the Makefiles
 AC_SUBST([PKG_HDF5])
 AC_SUBST([HDF5_LDFLAGS])
 AC_SUBST([HDF5_LIBS])
 AC_SUBST([HDF5_CFLAGS])
 AC_SUBST([HDF5_CPPFLAGS])
+
+# Append flags to global variables
 CPPFLAGS="${HDF5_CPPFLAGS} ${CPPFLAGS}"
 CFLAGS="${HDF5_CFLAGS} ${CFLAGS}"
 LDFLAGS="${HDF5_LDFLAGS} ${LDFLAGS}"
 LIBS="${HDF5_LIBS} ${LIBS}"
 
-AS_IF([test "x$with_hdf5" != "xno"], [
-  OLD_LIBS=$LIBS
-  AC_CHECK_LIB([hdf5], [H5Fcreate], [], [
-    AC_MSG_ERROR([-lhdf5 fails, use ./configure --with-hdf5=... OR check your $LIBRARY_PATH]) ])
-  AC_CHECK_HEADER([hdf5.h], [], [
-    AC_MSG_ERROR([hdf5.h not found, use ./configure --with-hdf5=...]) ])
-  LIBS=$OLD_LIBS
-])
+# Final link and header check (only if enabled)
+AS_IF([test "x$with_hdf5" != "xno"],
+  [
+    OLD_LIBS="$LIBS"
+    AC_CHECK_LIB([hdf5], [H5Fcreate],
+      [],
+      [AC_MSG_ERROR([HDF5 library (-lhdf5) not found or link failed. Provide --with-hdf5=PATH])]
+    )
+    AC_CHECK_HEADER([hdf5.h],
+      [],
+      [AC_MSG_ERROR([hdf5.h not found. Provide --with-hdf5=PATH or check CPPFLAGS])]
+    )
+    LIBS="$OLD_LIBS"
+  ]
+)
+####
 
 # The block below should only execute if the ax_lib_hdf5.m4 macro failed to find HDF5.
 # It is only needed to manually build Python API because setup.py depends on HDF5.
@@ -239,7 +265,7 @@ AC_C_INLINE
 # AC_FUNC_MALLOC
 AC_CHECK_FUNCS([memset mkdir strerror])
 
-if test "x$enable_maintainer_mode" == "xyes"; then
+if test "x$enable_maintainer_mode" = "xyes"; then
   TREXIO_DEVEL=" -- Developer mode"
 else
   TREXIO_DEVEL=""
@@ -278,7 +304,7 @@ if test "x${TREXIO_DEVEL}" != "x"; then
   #AX_SWIG_PYTHON
 
   AC_CHECK_PROGS([EMACS],[emacs26 emacs],[no])
-  if test x${EMACS} == xno ; then
+  if test x${EMACS} = "xno" ; then
     AC_MSG_ERROR([
     --------------------------------------
     Error: Emacs is required for org-mode.

--- a/configure.ac
+++ b/configure.ac
@@ -210,8 +210,8 @@ AS_IF([test "x$with_hdf5" = "xno"],
   )
 
   AC_DEFINE([HAVE_HDF5], 1, [Define to 1 if HDF5 is available])
-  AM_CONDITIONAL([HAVE_HDF5], [true])
 ])
+AM_CONDITIONAL([HAVE_HDF5], [test "x$with_hdf5" != "xno"])
 
 # Export variables to the Makefiles
 AC_SUBST([PKG_HDF5])

--- a/tools/build_json.sh
+++ b/tools/build_json.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Check that script is executed from tools directory
+if [[ $(basename $PWD) != "tools" ]] ; then
+  echo "This script should run in the tools directory"
+  exit -1
+fi
+
+TREXIO_ROOT=$(dirname "${PWD}../")
+
+#   First define readonly global variables.
+readonly SRC=${TREXIO_ROOT}/src
+readonly TOOLS=${TREXIO_ROOT}/tools
+
+# Function to produce TREXIO source files from org-mode files
+function tangle()
+{
+  emacs --batch "$1" \
+        --load=${TOOLS}/emacs/config_tangle.el \
+        --eval "(progn
+              (require 'ob)
+              (require 'ob-python)
+              (org-babel-execute-buffer)
+              (org-babel-tangle))" &> /dev/null
+}
+
+# Create trex.json file
+cd ${TREXIO_ROOT}
+tangle trex.org
+


### PR DESCRIPTION
HDF5 detection was hard to understand in configure.ac
I tried to simplify the structure of the HDF5 detection.
`test .. == ..` is not portable, so I replaced by `test .. = ..`

In the original version, when `--with-hdf5=yes` is used:
- If `pkg-config` fails to find HDF5 and `h5cc` is not found, the script continues execution.
- It still defines `HAVE_HDF5`, appends empty flags, and fails later during library checks.

In the updated version:
- If `pkg-config` fails and `h5cc` is not found, it immediately errors out with:
`AC_MSG_ERROR([HDF5 not found: install pkg-config .pc file or h5cc, or use --with-hdf5=PATH])`
This short-circuits the process and prevents `HAVE_HDF5` from being defined.
