### PR TITLE
nix: removes superfluous haskell overoverlay

### DIFF
--- a/tools/nix/overlay.nix
+++ b/tools/nix/overlay.nix
@@ -1,11 +1,3 @@
 final: prev: {
   trexio = final.callPackage ./trexio.nix { };
-
-  haskell = prev.haskell // {
-    packageOverrides = hfinal: hprev: {
-      trexio-hs = hfinal.callCabal2nix "trexio" ../haskell {
-        inherit (final) trexio;
-      };
-    };
-  };
 }


### PR DESCRIPTION
This removes the superfluous haskell overlay from Nix, which is not used anymore as the Haskell bindings ended up in a separate repo. It resolves evaluation issues with the Nix overlay in the Haskell package set.