### PR TITLE
Nix Build and CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -214,3 +214,11 @@ jobs:
 
       - name: clean
         run: make clean
+
+  trexio_nix:
+    name: Nix
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v31.4.1
+    - run: nix flake check -L && nix build -L

--- a/tools/nix/trexio.nix
+++ b/tools/nix/trexio.nix
@@ -41,6 +41,13 @@ stdenv.mkDerivation rec {
     hdf5
   ];
 
+  preConfigure = ''
+    cd ./tools
+    ./build_json.sh
+    ./build_trexio.sh
+    cd ..
+  '';
+
   outputs = [ "out" "dev" ];
 
   doCheck = true;


### PR DESCRIPTION
After my MR #186 has been merged, I've actually noticed that there is also a build failure with Nix due to slightly changed build system (sorry I haven't noticed that in the first place). This now fixes the CMake build failure in Nix and adds a Nix CI step so that this doesn't slip through again :)