### PR TITLE
cmake generation of trex.json

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,15 @@ find_package(Threads REQUIRED)
 include(CheckIncludeFile)
 check_include_file(stdint.h HAVE_STDINT_H)
 
+add_custom_command(
+        # note writing trex.json to src tree
+        COMMAND build_json.sh
+        OUTPUT  "${CMAKE_CURRENT_SOURCE_DIR}/../trex.json"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../trex.org"
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools
+        COMMENT "Generate trex.json from trex.org")
+
+
 # ========= DEFINE TREXIO C LIBRARY =========
 
 # Set a list of TREXIO source and header files that are always compiled.
@@ -128,6 +137,7 @@ if(TREXIO_DEVEL)
 	  ${TREXIO_MOD_FILE}
       COMMAND ./build_trexio.sh
       DEPENDS ${ORG_FILES} ${PROJECT_SOURCE_DIR}/include/config.h
+              "${CMAKE_CURRENT_SOURCE_DIR}/../trex.json"
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools
       COMMENT "Generating TREXIO source code from org-mode files."
       VERBATIM)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,15 +12,6 @@ find_package(Threads REQUIRED)
 include(CheckIncludeFile)
 check_include_file(stdint.h HAVE_STDINT_H)
 
-add_custom_command(
-        # note writing trex.json to src tree
-        COMMAND build_json.sh
-        OUTPUT  "${CMAKE_CURRENT_SOURCE_DIR}/../trex.json"
-        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../trex.org"
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools
-        COMMENT "Generate trex.json from trex.org")
-
-
 # ========= DEFINE TREXIO C LIBRARY =========
 
 # Set a list of TREXIO source and header files that are always compiled.
@@ -120,6 +111,14 @@ target_link_libraries(trexio_f PUBLIC trexio)
 
 # ====== CODE GENERATION FOR DEVEL MODE =====
 
+add_custom_command(
+        # note writing trex.json to src tree
+        COMMAND build_json.sh
+        OUTPUT  "${PROJECT_SOURCE_DIR}/trex.json"
+        DEPENDS "${PROJECT_SOURCE_DIR}/trex.org"
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools
+        COMMENT "Generate trex.json from trex.org")
+
 if(TREXIO_DEVEL)
   set(ORG_FILES
 	templates_front/templator_front.org
@@ -137,7 +136,7 @@ if(TREXIO_DEVEL)
 	  ${TREXIO_MOD_FILE}
       COMMAND ./build_trexio.sh
       DEPENDS ${ORG_FILES} ${PROJECT_SOURCE_DIR}/include/config.h
-              "${CMAKE_CURRENT_SOURCE_DIR}/../trex.json"
+              "${PROJECT_SOURCE_DIR}/trex.json"
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools
       COMMENT "Generating TREXIO source code from org-mode files."
       VERBATIM)


### PR DESCRIPTION
I think this step was missing for a pure cmake build? I need to look up CMAKE_CURRENT_ vs PROJECT_SOURCE_DIR before finalized for consideration.