### PR TITLE
Export the include directory to allow cmake in-source builds to find trexio_f.f90

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ set(TREXIO_MOD_FILE ${TREXIO_MOD_FILE} PARENT_SCOPE)
 # Add TREXIO Fortran module as a library.
 add_library(trexio_f SHARED)
 target_sources(trexio_f PUBLIC ${TREXIO_MOD_FILE})
+target_include_directories(trexio PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(trexio_f PUBLIC trexio)
 
 # ====== CODE GENERATION FOR DEVEL MODE =====


### PR DESCRIPTION
Otherwise, when doing a FetchContent build like

include(FetchContent)
FetchContent_Declare(trexio
        GIT_REPOSITORY https://github.com/TREX-CoE/trexio GIT_TAG v2.5.0
)
FetchContent_MakeAvailable(trexio)
target_link_libraries(trexio_integration_sandpit PRIVATE trexio)

one has to add something like

target_include_directories(trexio_integration_sandpit PRIVATE
            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/_deps/trexio-src/include>
)
