### PR TITLE
Fix compilation issues of Fortran binding with -fdefault-integer-8

### DIFF
--- a/src/templates_front/templator_front.org
+++ b/src/templates_front/templator_front.org
@@ -6942,7 +6942,9 @@ subroutine trexio_string_of_error (error, string)
    implicit none
    integer(trexio_exit_code), intent(in) :: error
    character*(*), intent(out)            :: string
-   call  trexio_string_of_error_f(error, len(string), string)
+   integer(c_int32_t)                    :: lenstring
+   lenstring = len(string)
+   call  trexio_string_of_error_f(error, lenstring, string)
 end subroutine trexio_string_of_error
   #+end_src
 
@@ -7104,7 +7106,7 @@ subroutine trexio_str2strarray(str_flat, max_num_str, max_len_str, str_array)
   implicit none
 
   integer(c_int64_t), intent(in), value   :: max_num_str  ! number of elements in strign array
-  integer, intent(in), value              :: max_len_str  ! maximum length of a string in an array
+  integer(c_int32_t), intent(in), value   :: max_len_str  ! maximum length of a string in an array
   character(kind=c_char), intent(in)      :: str_flat(*)
   character(len=*), intent(inout)         :: str_array(*)
 
@@ -7140,8 +7142,8 @@ end subroutine trexio_str2strarray
 subroutine trexio_assert(trexio_rc, check_rc, success_message)
   implicit none
 
-  integer, intent(in), value :: trexio_rc
-  integer, intent(in), value :: check_rc
+  integer(trexio_exit_code), intent(in), value :: trexio_rc
+  integer(trexio_exit_code), intent(in), value :: check_rc
   character(len=*), intent(in), optional  :: success_message
 
   character*(128) :: str


### PR DESCRIPTION
When a code uses the -fdefault-integer-8, including trexio_f.f90 generates errors due to missing type specifications. This PR fixes that.