### PR TITLE
Fix CMake failures due to missing .cmake file in the dist tarball

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -283,3 +283,62 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v31.4.1
     - run: nix flake check -L && nix build -L
+
+  trexio_release_tarball:
+    name: Test CMake build from release tarball
+    runs-on: ubuntu-22.04
+    steps:
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libhdf5-dev cmake
+
+      - name: get latest release
+        id: get_release
+        run: |
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/TREX-CoE/trexio/releases/latest | grep "tag_name" | cut -d '"' -f 4)
+          echo "tag=$LATEST_RELEASE" >> $GITHUB_OUTPUT
+          echo "Latest release: $LATEST_RELEASE"
+
+      - name: download release tarball
+        run: |
+          wget https://github.com/TREX-CoE/trexio/releases/download/${{ steps.get_release.outputs.tag }}/trexio-${LATEST_VERSION}.tar.gz
+        env:
+          LATEST_VERSION: ${{ steps.get_release.outputs.tag }}
+        continue-on-error: true
+
+      - name: download release tarball (alternative)
+        if: failure()
+        run: |
+          # Extract version without 'v' prefix
+          VERSION=$(echo "${{ steps.get_release.outputs.tag }}" | sed 's/^v//')
+          echo "Downloading version: $VERSION"
+          wget https://github.com/TREX-CoE/trexio/releases/download/${{ steps.get_release.outputs.tag }}/trexio-${VERSION}.tar.gz
+
+      - name: extract tarball
+        run: |
+          VERSION=$(echo "${{ steps.get_release.outputs.tag }}" | sed 's/^v//')
+          tar -xzf trexio-${VERSION}.tar.gz
+          echo "TREXIO_DIR=trexio-${VERSION}" >> $GITHUB_ENV
+
+      - name: configure with CMake
+        run: |
+          cd ${{ env.TREXIO_DIR }}
+          cmake -S. -Bbuild
+
+      - name: compile TREXIO
+        run: |
+          cd ${{ env.TREXIO_DIR }}/build
+          make -j2
+
+      - name: test TREXIO
+        run: |
+          cd ${{ env.TREXIO_DIR }}/build
+          ctest -j2
+
+      - name: Archive test log file
+        if: failure()
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          name: test-report-tarball
+          path: ${{ env.TREXIO_DIR }}/build/Testing/Temporary/LastTest.log

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -297,29 +297,16 @@ jobs:
         id: get_release
         run: |
           LATEST_RELEASE=$(curl -s https://api.github.com/repos/TREX-CoE/trexio/releases/latest | grep "tag_name" | cut -d '"' -f 4)
+          VERSION=$(echo "$LATEST_RELEASE" | sed 's/^v//')
           echo "tag=$LATEST_RELEASE" >> $GITHUB_OUTPUT
-          echo "Latest release: $LATEST_RELEASE"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Latest release: $LATEST_RELEASE (version: $VERSION)"
 
-      - name: download release tarball
+      - name: download and extract release tarball
         run: |
-          wget https://github.com/TREX-CoE/trexio/releases/download/${{ steps.get_release.outputs.tag }}/trexio-${LATEST_VERSION}.tar.gz
-        env:
-          LATEST_VERSION: ${{ steps.get_release.outputs.tag }}
-        continue-on-error: true
-
-      - name: download release tarball (alternative)
-        if: failure()
-        run: |
-          # Extract version without 'v' prefix
-          VERSION=$(echo "${{ steps.get_release.outputs.tag }}" | sed 's/^v//')
-          echo "Downloading version: $VERSION"
-          wget https://github.com/TREX-CoE/trexio/releases/download/${{ steps.get_release.outputs.tag }}/trexio-${VERSION}.tar.gz
-
-      - name: extract tarball
-        run: |
-          VERSION=$(echo "${{ steps.get_release.outputs.tag }}" | sed 's/^v//')
-          tar -xzf trexio-${VERSION}.tar.gz
-          echo "TREXIO_DIR=trexio-${VERSION}" >> $GITHUB_ENV
+          wget https://github.com/TREX-CoE/trexio/releases/download/${{ steps.get_release.outputs.tag }}/trexio-${{ steps.get_release.outputs.version }}.tar.gz
+          tar -xzf trexio-${{ steps.get_release.outputs.version }}.tar.gz
+          echo "TREXIO_DIR=trexio-${{ steps.get_release.outputs.version }}" >> $GITHUB_ENV
 
       - name: configure with CMake
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -285,7 +285,7 @@ jobs:
     - run: nix flake check -L && nix build -L
 
   trexio_release_tarball:
-    name: Test CMake build from release tarball
+    name: Test release tarball with CMake and autotools
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -325,9 +325,36 @@ jobs:
           cd ${{ env.TREXIO_DIR }}/build
           ctest -j2
 
-      - name: Archive test log file
+      - name: Archive CMake test log file
         if: failure()
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
-          name: test-report-tarball
+          name: test-report-tarball-cmake
           path: ${{ env.TREXIO_DIR }}/build/Testing/Temporary/LastTest.log
+
+      - name: clean CMake build
+        run: |
+          cd ${{ env.TREXIO_DIR }}
+          rm -rf build
+
+      - name: configure with autotools
+        run: |
+          cd ${{ env.TREXIO_DIR }}
+          ./configure --enable-silent-rules
+
+      - name: compile TREXIO with autotools
+        run: |
+          cd ${{ env.TREXIO_DIR }}
+          make -j2
+
+      - name: test TREXIO with autotools
+        run: |
+          cd ${{ env.TREXIO_DIR }}
+          make -j2 check
+
+      - name: Archive autotools test log file
+        if: failure()
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          name: test-report-tarball-autotools
+          path: ${{ env.TREXIO_DIR }}/test-suite.log

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -287,6 +287,8 @@ jobs:
   trexio_release_tarball:
     name: Test CMake build from release tarball
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: install dependencies
         run: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -90,7 +90,9 @@ EXTRA_DIST += CMakeLists.txt \
               src/CMakeLists.txt \
               tests/CMakeLists.txt \
               tests/test_macros.h  \
-              cmake/*
+              cmake/FindTREXIO.cmake \
+              cmake/cmake_uninstall.cmake.in \
+              cmake/standard_math_lib.cmake
 
 
 # =============== TESTS =============== #

--- a/Makefile.am
+++ b/Makefile.am
@@ -90,8 +90,7 @@ EXTRA_DIST += CMakeLists.txt \
               src/CMakeLists.txt \
               tests/CMakeLists.txt \
               tests/test_macros.h  \
-              cmake/cmake_uninstall.cmake.in \
-              cmake/FindTREXIO.cmake
+              cmake/*
 
 
 # =============== TESTS =============== #


### PR DESCRIPTION
conda-forge CI was failing because the recently added [standard_math_lib.cmake](https://github.com/TREX-CoE/trexio/blob/master/cmake/standard_math_lib.cmake) file was not included in the distribution tarball produced by Autotools. 

To prevent this in the future, I replace a list of files in the `Makefile.am` with a wildcard `cmake/*`. @scemama do you know if this is a good solution from the portability perspective? I guess the CI is a good test too.