### PR TITLE
docs: specify signed real solid harmonic phase convention (closes #244)

### DIFF
--- a/trex.org
+++ b/trex.org
@@ -793,6 +793,66 @@ power = [
    Note that for \(p\) orbitals in spherical coordinates, the ordering
    is $0,+1,-1$ which corresponds to $p_z, p_x, p_y$.
 
+   The ordering above fixes only the sequence of the functions, not
+   their sign relative to the Cartesian axes.  To remove any ambiguity,
+   TREXIO fixes the phase of the real solid harmonics as follows.
+   Writing the complex regular solid harmonics including the
+   Condon--Shortley phase as $C^m_\ell(\mathbf{r}) \equiv
+   \sqrt{\frac{4\pi}{2\ell+1}}\, r^\ell Y^m_\ell(\theta,\varphi)$, the
+   real functions $S^m_\ell$ used by TREXIO are
+
+   \[
+   S^{0}_\ell = C^{0}_\ell, \qquad
+   S^{+m}_\ell = \frac{(-1)^m}{\sqrt{2}}\left(C^{m}_\ell + C^{-m}_\ell\right), \qquad
+   S^{-m}_\ell = \frac{(-1)^m}{i\sqrt{2}}\left(C^{m}_\ell - C^{-m}_\ell\right)
+   \quad (m>0).
+   \]
+
+   Equivalently, $S^{+m}_\ell \propto \left(Y^{-m}_\ell + (-1)^m
+   Y^{m}_\ell\right)$ is the cosine ($\cos m\varphi$) combination and
+   $S^{-m}_\ell \propto i\left(Y^{-m}_\ell - (-1)^m Y^{m}_\ell\right)$
+   is the sine ($\sin m\varphi$) combination.  The factor $(-1)^m$
+   cancels the Condon--Shortley phase carried by $Y^m_\ell$, so the
+   resulting $S^m_\ell$ are real polynomials with a positive leading
+   coefficient (e.g. $S^{+1}_1 = +x$, $S^{-1}_1 = +y$, consistent with
+   the $p$ ordering above).  Explicitly, in Cartesian form (with
+   $r^2 = x^2 + y^2 + z^2$):
+
+   | $\ell$ | $m$  | $S^m_\ell(\mathbf{r})$                          |
+   |--------+------+------------------------------------------------|
+   | 0      | $0$  | $1$                                            |
+   | 1      | $0$  | $z$                                            |
+   | 1      | $+1$ | $x$                                            |
+   | 1      | $-1$ | $y$                                            |
+   | 2      | $0$  | $\frac{1}{2}(3z^2 - r^2)$                       |
+   | 2      | $+1$ | $\sqrt{3}\,xz$                                  |
+   | 2      | $-1$ | $\sqrt{3}\,yz$                                  |
+   | 2      | $+2$ | $\frac{\sqrt{3}}{2}(x^2 - y^2)$                 |
+   | 2      | $-2$ | $\sqrt{3}\,xy$                                  |
+   | 3      | $0$  | $\frac{1}{2}z(5z^2 - 3r^2)$                     |
+   | 3      | $+1$ | $\frac{\sqrt{6}}{4}x(5z^2 - r^2)$              |
+   | 3      | $-1$ | $\frac{\sqrt{6}}{4}y(5z^2 - r^2)$              |
+   | 3      | $+2$ | $\frac{\sqrt{15}}{2}z(x^2 - y^2)$              |
+   | 3      | $-2$ | $\sqrt{15}\,xyz$                                |
+   | 3      | $+3$ | $\frac{\sqrt{10}}{4}x(x^2 - 3y^2)$            |
+   | 3      | $-3$ | $\frac{\sqrt{10}}{4}y(3x^2 - y^2)$            |
+   | 4      | $0$  | $\frac{1}{8}(35z^4 - 30z^2 r^2 + 3r^4)$        |
+   | 4      | $+1$ | $\frac{\sqrt{10}}{4}xz(7z^2 - 3r^2)$          |
+   | 4      | $-1$ | $\frac{\sqrt{10}}{4}yz(7z^2 - 3r^2)$          |
+   | 4      | $+2$ | $\frac{\sqrt{5}}{4}(x^2 - y^2)(7z^2 - r^2)$    |
+   | 4      | $-2$ | $\frac{\sqrt{5}}{2}xy(7z^2 - r^2)$            |
+   | 4      | $+3$ | $\frac{\sqrt{70}}{4}xz(x^2 - 3y^2)$          |
+   | 4      | $-3$ | $\frac{\sqrt{70}}{4}yz(3x^2 - y^2)$          |
+   | 4      | $+4$ | $\frac{\sqrt{35}}{8}(x^4 - 6x^2 y^2 + y^4)$    |
+   | 4      | $-4$ | $\frac{\sqrt{35}}{2}xy(x^2 - y^2)$            |
+
+   The numerical prefactors correspond to the normalization implied by
+   the defining equation $S^m_\ell = \sqrt{\frac{4\pi}{2\ell+1}}\,
+   r^\ell Y^m_\ell$ (Racah / Schmidt semi-normalization); the overall
+   magnitude of each function is in any case rescaled by the
+   normalization factors $\mathcal{N}_i$ and $\mathcal{N}_i'$, so only
+   the relative signs of the entries above are normative.
+
    $\mathcal{N}_i'$ is a normalization factor that allows for different
    normalization coefficients within a single shell, as in the GAMESS
    convention where each individual function is unit-normalized.

--- a/trex.org
+++ b/trex.org
@@ -803,8 +803,8 @@ power = [
 
    \[
    S^{0}_\ell = C^{0}_\ell, \qquad
-   S^{+m}_\ell = \frac{(-1)^m}{\sqrt{2}}\left(C^{m}_\ell + C^{-m}_\ell\right), \qquad
-   S^{-m}_\ell = \frac{(-1)^m}{i\sqrt{2}}\left(C^{m}_\ell - C^{-m}_\ell\right)
+   S^{+m}_\ell = \frac{1}{\sqrt{2}}\left(C^{-m}_\ell + (-1)^m C^{m}_\ell\right), \qquad
+   S^{-m}_\ell = \frac{i}{\sqrt{2}}\left(C^{-m}_\ell - (-1)^m C^{m}_\ell\right)
    \quad (m>0).
    \]
 


### PR DESCRIPTION
## What

Makes the **sign/phase** of the real solid harmonics normative in `trex.org`, closing the gap reported in #244. The spec already fixed the *ordering* (`0, +1, −1, +2, −2, …`) but only anchored the *phase* relative to the Cartesian axes for the p shell (`+1 → p_x`, `−1 → p_y`); for ℓ ≥ 2 the per-`m` sign was left implicit and delegated to an external reference.

## Changes

Adds, right after the existing p-shell note in the AO section:

- the explicit cosine/sine real combinations — `+m` is the cosine (`∝ Y^{−m} + (−1)^m Y^m`) and `−m` the sine (`∝ i(Y^{−m} − (−1)^m Y^m)`) combination;
- a statement that the **Condon–Shortley phase is folded out**, so each `S^m_ℓ` is a real polynomial with positive leading coefficient (consistent with `S^{+1}_1 = +x`, `S^{−1}_1 = +y` and the existing p ordering);
- a **signed Cartesian table** of `S^m_ℓ` for ℓ = 0…4 (up to g);
- a note that the listed prefactors match the Racah/Schmidt semi-normalization implied by the defining equation `S^m_ℓ = √(4π/(2ℓ+1)) r^ℓ Y^m_ℓ`, and that since `N_i`/`N'_i` rescale each function, only the **relative signs** are normative.

## Notes

- Documentation-only: no tangled `src` block is touched, so `trex.json` and the generated headers are unaffected.
- The table follows the standard real regular solid harmonics (e.g. Helgaker, Jørgensen & Olsen, *Molecular Electronic-Structure Theory*, Table 6.3), which is the convention the existing p-shell anchor already implies.

Closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
