### PR TITLE
Updated CI workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,7 +24,7 @@ jobs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -45,7 +45,7 @@ jobs:
     needs: get_commit_message
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: check versions
         # TODO: bring back "diff configure_v python_v"
@@ -60,7 +60,7 @@ jobs:
           diff configure_v ocaml_v
 
       - name: setup fixed Python version for testing
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Archive test log file
         if: failure()
-        uses: actions/upload-artifact@v4 # v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-ubuntu
           path: test-suite.log
@@ -128,7 +128,7 @@ jobs:
         if: >-
           contains(needs.get_commit_message.outputs.message, '[wheel build]') &&
           matrix.os == 'ubuntu-22.04-arm'
-        uses: actions/upload-artifact@v4 # v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: pytrexio-source
           path: ./trexio-*.tar.gz
@@ -149,7 +149,7 @@ jobs:
 
       - name: Archive test log file
         if: failure()
-        uses: actions/upload-artifact@v4 # v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-ubuntu-memory
           path: test-suite.log
@@ -182,17 +182,17 @@ jobs:
       GCC_VERSION: 14
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: setup fixed Python version for testing
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
       - name: install dependencies
         run: |
           brew install emacs
-          brew install hdf5@1.10
+          brew install hdf5
           brew install automake
           brew install libtool
           pip install swig==4.3
@@ -200,7 +200,7 @@ jobs:
 
       - name: configure with autotools
         run: |
-          brew --prefix hdf5@1.10
+          brew --prefix hdf5
           ./autogen.sh
           ./configure CC=gcc-$GCC_VERSION FC=gfortran-$GCC_VERSION --enable-silent-rules
 
@@ -217,8 +217,8 @@ jobs:
 
       - name: compile Python API
         run: |
-          export H5_CFLAGS="-I$(brew --prefix hdf5@1.10)/include"
-          export H5_LDFLAGS="-L$(brew --prefix hdf5@1.10)/lib"
+          export H5_CFLAGS="-I$(brew --prefix hdf5)/include"
+          export H5_LDFLAGS="-L$(brew --prefix hdf5)/lib"
           source trexio-venv/bin/activate
           make python-install
 
@@ -229,7 +229,7 @@ jobs:
 
       - name: Archive test log file
         if: failure()
-        uses: actions/upload-artifact@v4 # v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-${{ matrix.os }}
           path: test-suite.log
@@ -244,7 +244,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
@@ -275,7 +275,7 @@ jobs:
 
       - name: Archive test log file
         if: failure()
-        uses: actions/upload-artifact@v4 # v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-windows
           path: test-suite.log
@@ -284,7 +284,7 @@ jobs:
     name: Nix
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: cachix/install-nix-action@v31.4.1
     - run: nix flake check -L && nix build -L
 
@@ -331,7 +331,7 @@ jobs:
 
       - name: Archive CMake test log file
         if: failure()
-        uses: actions/upload-artifact@v4 # v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-tarball-cmake
           path: ${{ env.TREXIO_DIR }}/build/Testing/Temporary/LastTest.log
@@ -358,7 +358,7 @@ jobs:
 
       - name: Archive autotools test log file
         if: failure()
-        uses: actions/upload-artifact@v4 # v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-tarball-autotools
           path: ${{ env.TREXIO_DIR }}/test-suite.log

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'trex-coe/trexio'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
            submodules: true  
 
@@ -44,4 +44,3 @@ jobs:
 
 #          github_token: ${{ secrets.GITHUB_TOKEN }}
 #          publish_dir: ./docs
-


### PR DESCRIPTION
## Summary

- Update NodesJS to Node 24 -> Suppresses warnings
- Fix MacOS runners with HDF5
