### PR TITLE
cmake: optionally install the compiled Fortran interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,20 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_TESTING "Whether to perform tests for TREXIO" ON)
 
 option(TREXIO_FORTRAN "Build and test the TREXIO Fortran interface" ON)
+
+# A project that adds TREXIO through add_subdirectory() or FetchContent links
+# the trexio_f target, so the Fortran library has to be installed along with the
+# rest of that project; installing the trexio_f.f90 source instead would leave
+# the installed consumer with a dangling dependency. A standalone build defaults
+# to the source, which is what the Autotools build installs as well.
+if(NOT TREXIO_FORTRAN OR CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(_trexio_install_fortran_library_default OFF)
+else()
+  set(_trexio_install_fortran_library_default ON)
+endif()
+option(TREXIO_INSTALL_FORTRAN_LIBRARY
+  "Install the compiled Fortran interface (libtrexio_f and the trexio module file) instead of the trexio_f.f90 source"
+  ${_trexio_install_fortran_library_default})
 option(TREXIO_USE_HDF5 "Enable HDF5 support" ON)
 option(TREXIO_BUILD_DOCS "Build and install documentation" OFF)
 
@@ -24,7 +38,20 @@ option(TREXIO_DEVEL "TREXIO developer mode (for code generation)." OFF)
 
 if(TREXIO_FORTRAN)
   enable_language(Fortran)
+elseif(TREXIO_INSTALL_FORTRAN_LIBRARY)
+  message(FATAL_ERROR
+    "TREXIO_INSTALL_FORTRAN_LIBRARY requires the Fortran interface; "
+    "reconfigure with -DTREXIO_FORTRAN=ON.")
 endif()
+
+include(GNUInstallDirs)
+
+# Fortran module files are specific to the compiler and even to its version, so
+# they cannot be shared the way C headers are. Distributions therefore keep them
+# in a separate directory (e.g. ${CMAKE_INSTALL_LIBDIR}/gfortran/modules), which
+# packagers can select here.
+set(TREXIO_INSTALL_MODULEDIR "${CMAKE_INSTALL_INCLUDEDIR}" CACHE STRING
+  "Installation directory for the Fortran module file, relative to CMAKE_INSTALL_PREFIX unless absolute")
 
 # The C99 requirement is expressed per target on the trexio library (see
 # src/CMakeLists.txt) rather than via the global CMAKE_C_STANDARD variable,

--- a/Makefile.am
+++ b/Makefile.am
@@ -96,7 +96,8 @@ EXTRA_DIST += CMakeLists.txt \
               cmake/cmake_uninstall.cmake.in \
               cmake/standard_math_lib.cmake \
               cmake/trexio-config.cmake.in \
-              cmake/trexio.pc.in
+              cmake/trexio.pc.in \
+              cmake/trexio_f.pc.in
 
 
 # =============== TESTS =============== #

--- a/README.md
+++ b/README.md
@@ -215,6 +215,34 @@ The aforementioned instructions rely on [Autotools](https://www.gnu.org/software
 By default, CMake builds a shared TREXIO library. Pass
 `-DBUILD_SHARED_LIBS=OFF` to build a static library instead.
 
+##### Installing a compiled Fortran interface
+
+In a standalone build, and like the Autotools build, the Fortran interface is
+installed as the `trexio_f.f90` source file in the include directory, and it is
+up to the consumer to compile it. Passing `-DTREXIO_INSTALL_FORTRAN_LIBRARY=ON`
+instead installs a compiled Fortran interface: the `trexio_f` library goes into
+the library directory, and the `trexio` module file into the Fortran module
+directory. Fortran codes can then simply `use trexio` and link against
+`-ltrexio_f`, either through the exported `trexio::trexio_f` CMake target or
+through the installed `trexio_f.pc` pkg-config file.
+
+The option is **on by default when TREXIO is built as a subproject**, i.e. when
+it is pulled in with `add_subdirectory()` or `FetchContent`. Such a project
+links the `trexio_f` target and finds the module in its include path, so the
+library has to be installed together with the rest of that project; installing
+the Fortran source instead would leave the installed consumer with a dangling
+dependency.
+
+Since Fortran module files are specific to the compiler and its version, the
+directory they are installed into can be chosen with
+`-DTREXIO_INSTALL_MODULEDIR=<dir>`; it defaults to the include directory. For
+example, on Fedora one would use
+
+```
+cmake -S. -Bbuild -DTREXIO_INSTALL_FORTRAN_LIBRARY=ON \
+      -DTREXIO_INSTALL_MODULEDIR=lib64/gfortran/modules
+```
+
 **Note**: on systems with no `sudo` access, one can add `-DCMAKE_INSTALL_PREFIX=build` as an argument to the `cmake` command so that `make install/uninstall` can be run without `sudo` privileges.
 
 **Note**: when linking against an MPI-enabled HDF5 library one usually has to specify the MPI wrapper for the C compiler by adding, e.g., `-DCMAKE_C_COMPILER=mpicc` to the `cmake` command.

--- a/cmake/trexio-config.cmake.in
+++ b/cmake/trexio-config.cmake.in
@@ -2,6 +2,9 @@
 
 set(TREXIO_VERSION @PROJECT_VERSION@)
 set(TREXIO_WITH_FORTRAN @TREXIO_FORTRAN@)
+# Whether the compiled Fortran interface (target trexio::trexio_f and the
+# accompanying module file) was installed alongside the C library.
+set(TREXIO_WITH_FORTRAN_LIBRARY @TREXIO_INSTALL_FORTRAN_LIBRARY@)
 set(TREXIO_WITH_HDF5 @TREXIO_USE_HDF5@)
 set(TREXIO_HDF5_IS_PARALLEL @TREXIO_HDF5_IS_PARALLEL@)
 

--- a/cmake/trexio_f.pc.in
+++ b/cmake/trexio_f.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@TREXIO_PC_LIBDIR@
+moduledir=@TREXIO_PC_MODULEDIR@
+
+Name: @PROJECT_NAME@_f
+Description: @PROJECT_DESCRIPTION@ (Fortran interface)
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires: trexio
+Libs: -L${libdir} -ltrexio_f
+Cflags: -I${moduledir}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,11 +61,16 @@ if(TREXIO_FORTRAN)
   set(_trexio_fortran_module_dir "${CMAKE_CURRENT_BINARY_DIR}/modules")
 
   add_library(trexio_f ${TREXIO_MOD_FILE})
+  add_library(trexio::trexio_f ALIAS trexio_f)
   target_link_libraries(trexio_f PUBLIC trexio::trexio)
   target_include_directories(trexio_f INTERFACE
     $<BUILD_INTERFACE:${_trexio_fortran_module_dir}>
+    $<INSTALL_INTERFACE:${TREXIO_INSTALL_MODULEDIR}>
   )
   set_target_properties(trexio_f PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    POSITION_INDEPENDENT_CODE ON
     Fortran_MODULE_DIRECTORY "${_trexio_fortran_module_dir}"
   )
 endif()
@@ -121,7 +126,28 @@ install(TARGETS trexio
 )
 
 if(TREXIO_FORTRAN)
-  install(FILES ${TREXIO_MOD_FILE} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  if(TREXIO_INSTALL_FORTRAN_LIBRARY)
+    # Install the compiled Fortran interface: the library goes next to the C
+    # one, and the module file it produces goes into the Fortran module
+    # directory. Consumers then link trexio::trexio_f instead of compiling
+    # trexio_f.f90 themselves.
+    install(TARGETS trexio_f
+      EXPORT trexio-targets
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+    # The name of the module file is compiler-dependent (trexio.mod or
+    # TREXIO.mod), and some compilers emit additional submodule files, so the
+    # whole module directory is installed rather than a single known file.
+    install(DIRECTORY "${_trexio_fortran_module_dir}/"
+      DESTINATION ${TREXIO_INSTALL_MODULEDIR}
+      FILES_MATCHING PATTERN "*.mod" PATTERN "*.smod"
+    )
+  else()
+    # Legacy behaviour: ship the Fortran source and let the consumer compile it.
+    install(FILES ${TREXIO_MOD_FILE} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  endif()
 endif()
 
 set(_trexio_install_cmakedir "${CMAKE_INSTALL_LIBDIR}/cmake/trexio")
@@ -193,6 +219,11 @@ if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
 else()
   set(TREXIO_PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 endif()
+if(IS_ABSOLUTE "${TREXIO_INSTALL_MODULEDIR}")
+  set(TREXIO_PC_MODULEDIR "${TREXIO_INSTALL_MODULEDIR}")
+else()
+  set(TREXIO_PC_MODULEDIR "\${prefix}/${TREXIO_INSTALL_MODULEDIR}")
+endif()
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/cmake/trexio.pc.in"
@@ -204,6 +235,20 @@ install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/trexio.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
+
+# The Fortran interface gets its own module, because it is a separate library
+# and its module file may live outside the include directory.
+if(TREXIO_FORTRAN AND TREXIO_INSTALL_FORTRAN_LIBRARY)
+  configure_file(
+    "${PROJECT_SOURCE_DIR}/cmake/trexio_f.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/trexio_f.pc"
+    @ONLY
+  )
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/trexio_f.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  )
+endif()
 
 # Install documentation
 if(TREXIO_BUILD_DOCS)


### PR DESCRIPTION
## Problem

The CMake build already compiles a Fortran interface library (`trexio_f`, needed by `test_f`), but never installs it. All that gets installed is the `trexio_f.f90` **source**, into the include directory, so every consumer has to compile the interface themselves.

## Change

A new option, `TREXIO_INSTALL_FORTRAN_LIBRARY`, installs the compiled interface instead:

* `libtrexio_f` is installed into the library directory, exported as `trexio::trexio_f`;
* the `trexio` module file is installed into `TREXIO_INSTALL_MODULEDIR`.

Module files are specific to the compiler and even to its version, so they do not belong in the plain include directory on multi-compiler systems. `TREXIO_INSTALL_MODULEDIR` defaults to the include directory (i.e. the current location) and packagers can point it elsewhere, e.g. `-DTREXIO_INSTALL_MODULEDIR=lib64/gfortran/modules`.

### Default

* **Subproject** (`add_subdirectory()` / `FetchContent`): **ON**. Such a project links the `trexio_f` target and finds the module in its include path, so the library has to be installed together with the rest of that project — installing the Fortran source instead would leave the installed consumer with a dangling `libtrexio_f.so` dependency.
* **Standalone build**: **OFF**, which keeps the previous behaviour and keeps the CMake and Autotools builds installing the same files. Shipping the `.f90` source remains the safe default there: a `.mod` is only usable by the exact compiler that produced it, and neither CMake's package version file nor libtool's `-version-info` can express that constraint.

The default is also OFF whenever `TREXIO_FORTRAN=OFF`, so a C-only parent project is unaffected.

### Supporting bits

* `trexio-config.cmake` reports `TREXIO_WITH_FORTRAN_LIBRARY` so consumers can test for the target.
* A `trexio_f.pc` is generated for consumers that use pkg-config rather than CMake, since the module directory need not be the include directory.
* The module directory is installed by pattern (`*.mod`, `*.smod`) rather than by file name, because the name is compiler-dependent (`trexio.mod` vs `TREXIO.mod`) and some compilers emit submodule files.
* Explicitly combining `-DTREXIO_INSTALL_FORTRAN_LIBRARY=ON -DTREXIO_FORTRAN=OFF` is a configure-time error rather than a silently ignored request.

The Autotools build is unchanged; it currently builds no Fortran library at all. It could gain the same option in a follow-up if packagers want it.

## Testing

Out-of-source builds, all with `ctest`:

| Configuration | Result |
| --- | --- |
| `-DTREXIO_INSTALL_FORTRAN_LIBRARY=ON -DTREXIO_INSTALL_MODULEDIR=lib/gfortran/modules` | 28/28; installs `libtrexio_f.so{,.2,.2.6.1}`, `lib/gfortran/modules/trexio.mod`, `trexio_f.pc`; no `trexio_f.f90` |
| `-DTREXIO_INSTALL_FORTRAN_LIBRARY=ON -DBUILD_SHARED_LIBS=OFF` | 28/28; `libtrexio_f.a` + `include/trexio.mod` |
| standalone default (`OFF`) | 28/28; install tree identical to before |
| `-DTREXIO_FORTRAN=OFF` | 27/27 |

Consumers of an installed TREXIO were built and run both ways — `find_package(trexio)` with `target_link_libraries(main PRIVATE trexio::trexio_f)`, and `gfortran $(pkg-config --cflags --libs trexio_f)` — with `use trexio` resolving in both.

A parent project pulling TREXIO in with `add_subdirectory()` was also built, run and installed: the option defaults to `ON`, the parent's Fortran executable compiles against the module from the build tree, and its `make install` produces `include/trexio.mod` plus `lib/libtrexio_f.so*` next to the parent's own binary. With `TREXIO_FORTRAN=OFF` the same parent configures cleanly with the option defaulted back to `OFF`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw2CsZM9bTs7YwjKULbXXs